### PR TITLE
Provide draft roxygent header for tags

### DIFF
--- a/R/get_tags.R
+++ b/R/get_tags.R
@@ -3,11 +3,16 @@
 #' At the moment, only tags that can be linked to a projectcode are returned to
 #' the user.
 #'
-#' @param connection
-#' @param animal_project
+#' @param connection A valid connection with the ETN database.
+#' @param animal_project (string) One or more animal projects.
 #'
-#' @return
+#' @return A data.frame.
+#'
 #' @export
+#'
+#' @importFrom glue glue_sql
+#' @importFrom DBI dbGetQuery
+#' @importFrom dplyr pull
 #'
 #' @examples
 #' \dontrun{

--- a/R/get_tags.R
+++ b/R/get_tags.R
@@ -1,3 +1,20 @@
+#' Get tags metadata
+#'
+#' At the moment, only tags that can be linked to a projectcode are returned to
+#' the user.
+#'
+#' @param connection
+#' @param animal_project
+#'
+#' @return
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#'   get_tags(con)
+#'   get_tags(con, animal_project = c("phd_reubens"))
+#' }
+
 get_tags <- function(connection,
                      animal_project = NULL) {
 


### PR DESCRIPTION
Provide basic functionality for the tags data. Remark that currently, only tags matching with projects are returned.