### PR TITLE
Receivers patch

### DIFF
--- a/R/get_receivers.R
+++ b/R/get_receivers.R
@@ -60,6 +60,7 @@ get_receivers <- function(connection,
   receivers %>%
     group_by(id_pk) %>%
     mutate(projectcode = paste(projectcode, collapse = ",")) %>%
+    rename(network_projectcode = projectcode) %>%
     ungroup() %>%
     distinct()
 }

--- a/R/get_receivers.R
+++ b/R/get_receivers.R
@@ -50,5 +50,13 @@ get_receivers <- function(connection,
                               .con = connection
   )
   receivers <- dbGetQuery(connection, receivers_query)
-  receivers
+
+  # we still have multiple records of receivers, as project codes are coupled to
+  # deployments and a receiver can have multiple deployments aka projects.
+  # combine the individual network projects in a single row:
+  receivers %>%
+    group_by(id_pk) %>%
+    mutate(projectcode  = paste(projectcode, collapse =",")) %>%
+    ungroup() %>%
+    distinct()
 }

--- a/R/get_receivers.R
+++ b/R/get_receivers.R
@@ -42,7 +42,7 @@ get_receivers <- function(connection,
   }
 
   receivers_query <- glue_sql("
-      SELECT receivers.* , deployments.projectcode
+      SELECT DISTINCT receivers.* , deployments.projectcode
       FROM vliz.receivers
         JOIN vliz.deployments_view deployments ON (receivers.id_pk = deployments.receiver_fk)
       WHERE projectcode IN ({project*})",

--- a/R/get_receivers.R
+++ b/R/get_receivers.R
@@ -42,9 +42,12 @@ get_receivers <- function(connection,
   }
 
   receivers_query <- glue_sql("
-      SELECT DISTINCT receivers.* , deployments.projectcode
+      SELECT DISTINCT receivers.* ,
+        deployments.projectcode,
+        etn_group.name as owner_organisation
       FROM vliz.receivers
         JOIN vliz.deployments_view deployments ON (receivers.id_pk = deployments.receiver_fk)
+        JOIN vliz.etn_group AS etn_group ON (receivers.owner_group_fk = etn_group.id_pk)
       WHERE projectcode IN ({project*})",
                               project = network_project,
                               .con = connection
@@ -56,7 +59,7 @@ get_receivers <- function(connection,
   # combine the individual network projects in a single row:
   receivers %>%
     group_by(id_pk) %>%
-    mutate(projectcode  = paste(projectcode, collapse =",")) %>%
+    mutate(projectcode = paste(projectcode, collapse = ",")) %>%
     ungroup() %>%
     distinct()
 }

--- a/tests/testthat/test_get_receivers.R
+++ b/tests/testthat/test_get_receivers.R
@@ -28,5 +28,6 @@ testthat::test_that("test_output_get_receivers", {
   expect_equal(ncol(test1), ncol(test2))
   expect_equal(ncol(test2), ncol(test3))
   expect_true("owner_organisation" %in% colnames(test1))
+  expect_true("network_projectcode" %in% colnames(test1))
 })
 

--- a/tests/testthat/test_get_receivers.R
+++ b/tests/testthat/test_get_receivers.R
@@ -22,10 +22,11 @@ testthat::test_that("test_output_get_receivers", {
   expect_is(test1, "data.frame")
   expect_is(test2, "data.frame")
   expect_is(test3, "data.frame")
-  expect_gte(nrow(test1), nrow(test2))
+  expect_gt(nrow(test1), nrow(test2))
   expect_gte(nrow(test1), nrow(test3))
   expect_gte(nrow(test3), nrow(test2))
   expect_equal(ncol(test1), ncol(test2))
   expect_equal(ncol(test2), ncol(test3))
+  expect_true("owner_organisation" %in% colnames(test1))
 })
 


### PR DESCRIPTION
This PR tackles the discussion of issue #41:
- it removes the duplicate rows of receivers when multiple deployments where done on a single receiver; as this still results in multiple network_projects linked to a single receiver (networks are linked to deployments, hence, when these deployments had different projects, the receiver is linked to multiple network projects), the column network_projectcode provides a combined list of projects, separated by `,`
- is adds the owner_organisation column by joining the etn_group table

as an example (just a subset of the columns and rows):

|serial_number |status    |network_projectcode                     |owner_organisation |
|:-------------|:---------|:-------------------------------|:------------------|
|113528        |Active    |leopold,zeeschelde,bovenschelde |INBO               |
|3110          |Active    |cpod-lifewatch                  |VLIZ               |
|113524        |Active    |dijle,bovenschelde,leopold      |INBO               |
|124072        |Lost      |albert                          |INBO               |
|546193        |Available |MorayFirth                      |AST                |
|129709        |Active    |bpns,Noordzeekanaal             |VLIZ               |

remark, I do NOT
- add the animal_project as additional filter, see #43 discussion
- add the owner_organisation as filter, as this is only one command away, e.g. `get_receivers(con) %>% filter(owner_organisation == "INBO")`
