### PR TITLE
Critical bug fix to filter projects properly

### DIFF
--- a/R/get_projects.R
+++ b/R/get_projects.R
@@ -29,6 +29,8 @@
 #' }
 get_projects <- function(connection, project_type = NULL) {
 
+  animal_network <- project_type
+
   check_connection(connection)
   check_null_or_value(project_type, c("animal", "network"),
                       "project_type")
@@ -40,7 +42,7 @@ get_projects <- function(connection, project_type = NULL) {
   projects <- dbGetQuery(connection, projects)
 
   if (!is.null(project_type)) {
-    projects <- projects %>% filter(.data$type == project_type)
+    projects <- projects %>% filter(.data$type == animal_network)
 
   }
   projects


### PR DESCRIPTION
This PR is a critical bug fix in order to make project filtering possible again on `network` or `animal`, see issue #59.