### PR TITLE
Adding unit-tests to check column names in db views

### DIFF
--- a/tests/testthat/test_get_animals.R
+++ b/tests/testthat/test_get_animals.R
@@ -6,18 +6,91 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
+# Valid column names
+valid_col_names_animals <- c(
+"projectname",
+"projectmember",
+"tag_code_space",
+"person_id",
+"animal_id",
+"scientific_name",
+"common_name",
+"length",
+"length_type",
+"length_units",
+"length2",
+"length2_type",
+"length2_units",
+"weight_units",
+"age",
+"age_units",
+"sex",
+"life_stage",
+"capture_location",
+"capture_depth",
+"utc_release_date_time",
+"comments",
+"est_tag_life","wild_or_hatchery",
+"stock",
+"dna_sample_taken",
+"treatment_type",
+"dissolved_oxygen",
+"sedative",
+"sedative_concentration",
+"temperature_change",
+"holding_temperature",
+"preop_holding_period",
+"post_op_holding_period",
+"surgery_location",
+"date_of_surgery",
+"anaesthetic","buffer",
+"anaesthetic_concentration",
+"buffer_concentration_in_anaesthetic",
+"anesthetic_concentration_in_recirculation",
+"buffer_concentration_in_recirculation",
+"id_pk",
+"catched_date_time",
+"capture_latitude",
+"capture_longitude",
+"release_latitude",
+"release_longitude",
+"surgery_latitude",
+"surgery_longitude",
+"recapture_date",
+"implant_type",
+"implant_method",
+"date_modified",
+"date_created",
+"release_location",
+"length3",
+"length3_type",
+"length3_units",
+"length4",
+"length4_type",
+"length4_units",
+"weight",
+"end_date_tag",
+"capture_method",
+"project_fk",
+"animal_tag_release_id_pk",
+"thelma_converted_code",
+"projectcode",
+"tag_full_id"
+)
+
 test1 <- get_animals(con, network_project = NULL)
-test2 <- get_animals(con, network_project = "thornton")
+test2 <- get_animals(con, animal_project = "phd_reubens")
 test3 <- get_animals(con, animal_project = "2012_leopoldkanaal")
 
-projects_test4 <- c("2012_leopoldkanaal", "phd_reubens")
+projects_test4 <- c("phd_reubens", "2012_leopoldkanaal")
 test4 <- get_animals(con, animal_project = projects_test4)
-animals_test4 <- c("Gadus morhua", "Sentinel", "Anguilla anguilla")
-test5 <- get_animals(con, scientific_name = animals_test4)
+animals_test5 <- c("Gadus morhua", "Sentinel", "Anguilla anguilla")
+test5 <- get_animals(con, scientific_name = animals_test5)
 animals_test6 <- c("Gadus morhua")
 projects_test6 <- "phd_reubens"
-test6 <- get_animals(con, animal_project = "phd_reubens",
+test6 <- get_animals(con, animal_project = projects_test6,
                      scientific_name = animals_test6)
+test7 <- get_animals(con, network_project = "thornton")
 
 testthat::test_that("test_input_get_animals", {
   expect_error(get_animals("I am not a connection"),
@@ -26,31 +99,67 @@ testthat::test_that("test_input_get_animals", {
 
 
 testthat::test_that("test_output_get_animals", {
+  library(dplyr)
   expect_is(test1, "data.frame")
   expect_is(test2, "data.frame")
+  expect_is(test3, "data.frame")
+  expect_is(test4, "data.frame")
+  expect_is(test5, "data.frame")
+  expect_is(test6, "data.frame")
+  expect_is(test7, "data.frame")
+  expect_true(all(names(test1) %in% valid_col_names_animals))
+  expect_true(all(valid_col_names_animals %in% names(test1)))
   expect_gte(nrow(test1), nrow(test2))
   expect_gte(nrow(test1), nrow(test3))
   expect_gte(nrow(test1), nrow(test4))
-  expect_gte(nrow(test4), nrow(test3))
   expect_gte(nrow(test1), nrow(test5))
-  expect_gte(nrow(test5), nrow(test6))
-  expect_equal(ncol(test1), ncol(test2))
-  expect_equal(ncol(test2), ncol(test3))
-  expect_equal(ncol(test3), ncol(test4))
-  expect_equal(ncol(test5), ncol(test6))
-  expect_identical(animals_test4,
-                   test4 %>%
-                     dplyr::distinct(scientific_name) %>%
-                     dplyr::pull(scientific_name))
+  expect_gte(nrow(test1), nrow(test6))
+  expect_gte(nrow(test1), nrow(test7))
+  expect_equal(names(test1), names(test2))
+  expect_equal(names(test1), names(test3))
+  expect_equal(names(test1), names(test4))
+  expect_equal(names(test1), names(test5))
+  expect_equal(names(test1), names(test6))
+  expect_equal(names(test1), names(test7))
+  expect_gte(test1 %>%
+               distinct(scientific_name) %>%
+               pull() %>%
+               length(),
+             test4 %>%
+               distinct(scientific_name) %>%
+               pull() %>%
+               length()
+  )
+  expect_lte(test4 %>%
+                     distinct(scientific_name) %>%
+                     pull() %>%
+                     length(),
+                   (test2 %>%
+                      distinct(scientific_name) %>%
+                      pull() %>%
+                      length() +
+                    test3 %>%
+                      distinct(scientific_name) %>%
+                      pull() %>%
+                      length())
+  )
   expect_true(all(projects_test4 %in% (test5 %>%
-                                         dplyr::distinct(projectcode) %>%
-                                         dplyr::pull(projectcode))))
+                                         distinct(projectcode) %>%
+                                         pull()))
+  )
   expect_identical(test6 %>%
-                     dplyr::distinct(scientific_name) %>%
-                     dplyr::pull(scientific_name),
-                   animals_test6)
+                     distinct(scientific_name) %>%
+                     pull(scientific_name),
+                   animals_test6
+  )
   expect_identical(test6 %>%
-                     dplyr::distinct(projectcode) %>%
-                     dplyr::pull(projectcode),
-                   projects_test6)
+                     distinct(projectcode) %>%
+                     pull(projectcode),
+                   projects_test6
+  )
+  expect_true(all(projects_test4 %in%
+                    (test7 %>%
+                       distinct(projectcode) %>%
+                       pull()))
+  )
 })

--- a/tests/testthat/test_get_deployments.R
+++ b/tests/testthat/test_get_deployments.R
@@ -6,6 +6,61 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
+# valid column names
+valid_col_names_deployments <- c(
+  "receiver",
+  "receiver_status",
+  "projectname",
+  "projectcode",
+  "projectmember",
+  "drop_dead_date",
+  "download_date_time",
+  "deploy_date_time",
+  "recover_date_time",
+  "bottom_depth",
+  "riser_length",
+  "instrument_depth",
+  "check_complete_time",
+  "sync_date_time",
+  "voltage_at_deploy",
+  "ar_confirm",
+  "data_downloaded",
+  "voltage_at_download",
+  "time_drift",
+  "comments",
+  "id_pk",
+  "receiver_fk",
+  "location_name",
+  "location_manager",
+  "location_description",
+  "deploy_lat",
+  "deploy_long",
+  "recover_lat",
+  "recover_long",
+  "station_name",
+  "intended_lat",
+  "intended_long",
+  "date_created",
+  "date_modified",
+  "battery_install_date",
+  "ar_battery_install_date",
+  "distance_to_mouth",
+  "source",
+  "transmit_profile",
+  "transmit_power_output",
+  "log_temperature_stats_period",
+  "log_temperature_sample_period",
+  "log_tilt_sample_period",
+  "log_noise_stats_period",
+  "log_noise_sample_period",
+  "log_depth_stats_period",
+  "log_depth_sample_period",
+  "project_fk",
+  "mooring_type",
+  "deployment_type",
+  "activation_datetime",
+  "valid_data_until_datetime"
+)
 test1 <- get_deployments(con)
 test2 <- get_deployments(con, network_project = "thornton")
 test3 <- get_deployments(con, network_project = c("thornton",
@@ -34,14 +89,17 @@ testthat::test_that("test_output_get_deployments", {
   expect_is(test1, "data.frame")
   expect_is(test2, "data.frame")
   expect_is(test3, "data.frame")
+  expect_true(all(names(test1) %in% valid_col_names_deployments))
+  expect_true(all(valid_col_names_deployments %in% names(test1)))
   expect_gte(nrow(test1), nrow(test2))
   expect_gte(nrow(test1), nrow(test3))
   expect_gte(nrow(test3), nrow(test2))
   expect_gte(nrow(test5), nrow(test4))
-  expect_equal(ncol(test1), ncol(test2))
-  expect_equal(ncol(test2), ncol(test3))
-  expect_equal(ncol(test3), ncol(test4))
-  expect_equal(ncol(test4), ncol(test5))
+  expect_equal(names(test1), names(test2))
+  expect_equal(names(test1), names(test3))
+  expect_equal(names(test1), names(test4))
+  expect_equal(names(test1), names(test5))
+  expect_equal(names(test1), names(test6))
   expect_gte(test1 %>% distinct(receiver_status) %>% nrow(),
              test2 %>% distinct(receiver_status) %>% nrow())
   expect_gte(test3 %>% distinct(receiver_status) %>% nrow(),

--- a/tests/testthat/test_get_detections.R
+++ b/tests/testthat/test_get_detections.R
@@ -6,6 +6,48 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
+# Valid column names
+valid_col_names_detections <- c(
+  "receiver",
+  "transmitter",
+  "transmitter_name",
+  "transmitter_serial",
+  "sensor_value",
+  "sensor_unit",
+  "sensor2_value",
+  "sensor2_unit",
+  "station_name",
+  "datetime",
+  "id_pk",
+  "qc_flag",
+  "file","latitude",
+  "longitude",
+  "deployment_fk",
+  "scientific_name",
+  "location_name",
+  "deployment_station_name",
+  "deploy_date_time",
+  "animal_project_name",
+  "animal_project_code",
+  "animal_moratorium",
+  "network_project_name",
+  "network_project_code",
+  "network_moratorium",
+  "signal_to_noise_ratio",
+  "detection_file_id",
+  "tag_sensor_type",
+  "tag_intercept",
+  "tag_slope",
+  "sensor_value_depth_meters",
+  "tag_owner_organization",
+  "animal_id_pk",
+  "animal_common_name",
+  "animal_sex",
+  "deployment_lat",
+  "deployment_long",
+  "sensor_value_acceleration"
+)
+
 testthat::test_that("test_input_get_detections", {
   expect_error(get_detections("I am not a connection"),
                "Not a connection object to database.")
@@ -77,12 +119,22 @@ test6 <- get_detections(con, receiver = receiver, limit = limit)
 test7 <- get_detections(con, scientific_name = scientific_name, limit = limit)
 
 testthat::test_that("test_output_get_detections", {
+  library(dplyr)
+  expect_is(test1, "data.frame")
+  expect_is(test2, "data.frame")
+  expect_is(test3, "data.frame")
+  expect_is(test4, "data.frame")
+  expect_is(test5, "data.frame")
+  expect_true(all(names(test1) %in% valid_col_names_detections))
+  expect_true(all(valid_col_names_detections %in% names(test1)))
   expect_equal(nrow(test1), 5)
   expect_equal(nrow(test2), 2)
-  expect_equal(ncol(test1), ncol(test2))
-  expect_equal(ncol(test2), ncol(test3))
-  expect_equal(ncol(test3), ncol(test4))
-  expect_equal(ncol(test4), ncol(test5))
+  expect_equal(names(test1), names(test2))
+  expect_equal(names(test1), names(test3))
+  expect_equal(names(test1), names(test4))
+  expect_equal(names(test1), names(test5))
+  expect_equal(names(test1), names(test6))
+  expect_equal(names(test1), names(test7))
   expect_true(test1 %>%
                  select(datetime) %>%
                  summarize(min_datetime = min(datetime)) %>%
@@ -119,4 +171,3 @@ testthat::test_that("test_output_get_detections", {
                 distinct(scientific_name) %>%
                 pull() == scientific_name)
 })
-

--- a/tests/testthat/test_get_projects.R
+++ b/tests/testthat/test_get_projects.R
@@ -6,6 +6,21 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
+# Valid column names
+valid_col_names_projects <- c(
+  "id",
+  "name",
+  "projectcode",
+  "type",
+  "startdate",
+  "enddate",
+  "moratorium",
+  "imis_dataset_id",
+  "latitude","longitude",
+  "context_type",
+  "principal_investigator"
+)
+
 testthat::test_that("test_input_get_projects", {
   expect_error(get_projects("I am not a connection"),
                "Not a connection object to database.")
@@ -26,10 +41,12 @@ testthat::test_that("test_output_get_projects", {
   expect_is(prjcts, "data.frame")
   expect_is(prjcts_animal, "data.frame")
   expect_is(prjcts_network, "data.frame")
+  expect_true(all(names(prjcts) %in% valid_col_names_projects))
+  expect_true(all(valid_col_names_projects %in% names(prjcts)))
   expect_gte(nrow(prjcts), nrow(prjcts_animal))
   expect_gte(nrow(prjcts), nrow(prjcts_network))
   expect_equivalent(nrow(prjcts),
                     nrow(prjcts_network) + nrow(prjcts_animal))
-  expect_equal(ncol(prjcts), ncol(prjcts_animal))
-  expect_equal(ncol(prjcts_animal), ncol(prjcts_network))
+  expect_equal(names(prjcts), names(prjcts_animal))
+  expect_equal(names(prjcts_animal), names(prjcts_network))
 })

--- a/tests/testthat/test_get_receivers.R
+++ b/tests/testthat/test_get_receivers.R
@@ -6,6 +6,37 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
+# valid column names
+valid_col_names_receivers <- c(
+    "serial_number",
+    "model_number",
+    "modem_address",
+    "expected_battery_life",
+    "ar_model_number",
+    "ar_serial_number",
+    "ar_expected_battery_life",
+    "ar_voltage_at_deploy",
+    "ar_tilt_after_deploy",
+    "ar_interrogate_code",
+    "ar_receive_frequency",
+    "ar_reply_frequency",
+    "ar_ping_rate",
+    "ar_enable_code_address",
+    "ar_release_code",
+    "ar_disable_code",
+    "ar_tilt_code",
+    "id_pk",
+    "receiver",
+    "built_in_tag_fk",
+    "status",
+    "receiver_type",
+    "manufacturer_fk",
+    "owner_group_fk",
+    "financing_project_fk",
+    "projectcode",
+    "owner_organisation"
+)
+
 test1 <- get_receivers(con)
 test2 <- get_receivers(con, network_project = "thornton")
 test3 <- get_receivers(con, network_project = c("thornton", "leopold"))
@@ -22,12 +53,12 @@ testthat::test_that("test_output_get_receivers", {
   expect_is(test1, "data.frame")
   expect_is(test2, "data.frame")
   expect_is(test3, "data.frame")
+  expect_true(all(names(test1) %in% valid_col_names_receivers))
+  expect_true(all(valid_col_names_receivers %in% names(test1)))
   expect_gt(nrow(test1), nrow(test2))
   expect_gte(nrow(test1), nrow(test3))
   expect_gte(nrow(test3), nrow(test2))
-  expect_equal(ncol(test1), ncol(test2))
-  expect_equal(ncol(test2), ncol(test3))
-  expect_true("owner_organisation" %in% colnames(test1))
-  expect_true("projectcode" %in% colnames(test1))
+  expect_equal(names(test1), names(test2))
+  expect_equal(names(test1), names(test3))
 })
 

--- a/tests/testthat/test_get_transmitters.R
+++ b/tests/testthat/test_get_transmitters.R
@@ -6,6 +6,58 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
+# valid column names
+valid_col_names_transmitters <- c(
+  "serial_number",
+  "type",
+  "model",
+  "id_code",
+  "tag_code_space",
+  "owner_pi",
+  "id_pk",
+  "activation_date",
+  "min_delay",
+  "max_delay",
+  "power",
+  "end_date",
+  "file",
+  "estimated_lifetime",
+  "sensor_type",
+  "frequency",
+  "acoustic_tag_type",
+  "min_delay_step2",
+  "max_delay_step2",
+  "power_step2",
+  "min_delay_step3",
+  "max_delay_step3",
+  "power_step3",
+  "duration_step1",
+  "duration_step2",
+  "duration_step3",
+  "manufacturer_fk",
+  "intercept",
+  "slope",
+  "owner_group_fk",
+  "thelma_converted_code",
+  "financing_project_fk",
+  "acceleration_on_sec_step1",
+  "acceleration_on_sec_step2",
+  "acceleration_on_sec_step3",
+  "min_delay_step4",
+  "max_delay_step4",
+  "power_step4",
+  "duration_step4",
+  "acceleration_on_sec_step4",
+  "range",
+  "units",
+  "accelerometer_algoritm",
+  "accelerometer_samples_per_second",
+  "sensor_transmit_ratio",
+  "tag_full_id",
+  "status",
+  "projectcode"
+)
+
 test1 <- get_transmitters(con)
 test2 <- get_transmitters(con, animal_project = "phd_reubens")
 test3 <- get_transmitters(con, animal_project = c("phd_reubens",
@@ -24,18 +76,20 @@ testthat::test_that("test_input_get_transmitters", {
 })
 
 testthat::test_that("test_output_get_transmitters", {
+  library(dplyr)
   expect_is(test1, "data.frame")
   expect_is(test2, "data.frame")
   expect_is(test3, "data.frame")
   expect_is(test4, "data.frame")
+  expect_true(all(names(test1) %in% valid_col_names_transmitters))
+  expect_true(all(valid_col_names_transmitters %in% names(test1)))
   expect_gte(nrow(test1), nrow(test2))
   expect_gte(nrow(test1), nrow(test3))
   expect_gte(nrow(test3), nrow(test2))
   expect_gte(nrow(test4), nrow(test2))
-  expect_equal(ncol(test1), ncol(test2))
-  expect_equal(ncol(test1), ncol(test3))
-  expect_equal(ncol(test3), ncol(test2))
-  expect_equal(ncol(test4), ncol(test2))
+  expect_equal(names(test1), names(test2))
+  expect_equal(names(test1), names(test3))
+  expect_equal(names(test1), names(test4))
   expect_equal(test2 %>%
                  distinct(acoustic_tag_type) %>%
                  pull(), c("sentinel","animal"))


### PR DESCRIPTION
This PR improves unit-tests. In particular, tests of column names of db views as returned by all `get_*()` functions have been added. 

The unit-tests will throw an error if:
1. A new column has been added
2. A column name has been changed
3. A column has been removed

The unit-tests will NOT throw an error if:
1. the order of the columns has been changed 

Some minor changes about code uniformity and general improvements of unit-tests have been applied as well.