### PR TITLE
Update parameters for get_tags and get_receivers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etn
 Title: Access and Process Data from the European Tracking Network
-Version: 0.1.0.9093
+Version: 0.1.0.9101
 Description: Package with functions to access and process data from the European
     Tracking Network hosted by VLIZ.
 Authors@R: c(

--- a/R/connect_to_etn.R
+++ b/R/connect_to_etn.R
@@ -14,7 +14,8 @@
 #' \dontrun{
 #' con <- connect_to_etn(Sys.getenv("userid"), Sys.getenv("pwd"))
 #' }
-connect_to_etn <- function(username, password) {
+connect_to_etn <- function(username,
+                           password) {
   ETN_ODBC_DSN <- "ETN"
   # ETN_SERVER <- "dppg.vliz.be"
   # ETN_DBNAME <- "ETN"

--- a/R/connect_to_etn.R
+++ b/R/connect_to_etn.R
@@ -9,6 +9,11 @@
 #'
 #' @importFrom DBI dbConnect
 #' @importFrom odbc odbc
+#'
+#' @examples
+#' \dontrun{
+#' con <- connect_to_etn(Sys.getenv("userid"), Sys.getenv("pwd")))
+#' }
 connect_to_etn <- function(username, password) {
   ETN_ODBC_DSN <- "ETN"
   # ETN_SERVER <- "dppg.vliz.be"

--- a/R/connect_to_etn.R
+++ b/R/connect_to_etn.R
@@ -12,7 +12,7 @@
 #'
 #' @examples
 #' \dontrun{
-#' con <- connect_to_etn(Sys.getenv("userid"), Sys.getenv("pwd")))
+#' con <- connect_to_etn(Sys.getenv("userid"), Sys.getenv("pwd"))
 #' }
 connect_to_etn <- function(username, password) {
   ETN_ODBC_DSN <- "ETN"

--- a/R/get_animals.R
+++ b/R/get_animals.R
@@ -33,7 +33,7 @@
 #' # Get animals of a specific species from a specific project
 #' get_animals(con, animal_project_code = "phd_reubens", scientific_name = "Gadus morhua")
 #' }
-get_animals <- function(connection,
+get_animals <- function(connection = con,
                         animal_project_code = NULL,
                         scientific_name = NULL) {
   # Check connection

--- a/R/get_deployments.R
+++ b/R/get_deployments.R
@@ -30,13 +30,13 @@
 #' get_deployments(con, open_only = FALSE)
 #'
 #' # Get open deployments from specific network project(s)
-#' get_deployments(con, network_project_code = c("thornton", "leopold"))
+#' get_deployments(con, network_project_code = c("ws1", "ws2"))
 #'
 #' # Get open deployments with a specific receiver status
 #' get_deployments(con, receiver_status = c("Broken", "Lost"))
 #'
 #' # Get open deployments from a specific project from active receivers
-#' get_deployments(con, network_project_code = "thornton", receiver_status = "Active")
+#' get_deployments(con, network_project_code = "ws1", receiver_status = "Active")
 #' }
 get_deployments <- function(connection = con,
                             network_project_code = NULL,

--- a/R/get_deployments.R
+++ b/R/get_deployments.R
@@ -6,8 +6,8 @@
 #' @param connection A valid connection to the ETN database.
 #' @param network_project_code (string) One or more network projects.
 #' @param receiver_status (string) One or more receiver status.
-#' @param open_only (logical) Restrict to deployments that are currently open (i.e. no end date defined).  Default:
-#'   `TRUE`.
+#' @param open_only (logical) Restrict to deployments that are currently open
+#'   (i.e. no end date defined). Default: `TRUE`.
 #'
 #' @return A tibble (tidyverse data.frame).
 #'
@@ -38,7 +38,7 @@
 #' # Get open deployments from a specific project from active receivers
 #' get_deployments(con, network_project_code = "thornton", receiver_status = "Active")
 #' }
-get_deployments <- function(connection,
+get_deployments <- function(connection = con,
                             network_project_code = NULL,
                             receiver_status = NULL,
                             open_only = TRUE) {

--- a/R/get_detections.R
+++ b/R/get_detections.R
@@ -17,8 +17,8 @@
 #' @param tag_id (character) One or more tag identifiers.
 #' @param receiver_id (character) One or more receiver identifiers.
 #' @param scientific_name (character) One or more scientific names.
-#' @param limit (integer) The number of records to return (useful for testing
-#'   purposes).
+#' @param limit (logical) Limit the number of returned records to 100 (useful for testing
+#'   purposes). Default: `TRUE`.
 #'
 #' @return A tibble (tidyverse data.frame).
 #'
@@ -35,43 +35,55 @@
 #' \dontrun{
 #' con <- connect_to_etn(your_username, your_password)
 #'
-#' # Get detections filtered by start year and limited to 100 records
-#' get_detections(con, start_date = "2017", limit = 100)
+#' # Get detections filtered by start year, limited to 100 records by default
+#' get_detections(con, start_date = "2017")
 #'
 #' # Get detections within a time frame for a specific animal project and
 #' # network project
-#' get_detections(con,
+#' get_detections(
+#'   con,
 #'   animal_project_code = "phd_reubens",
 #'   network_project_code = "thornton", start_date = "2011-01-28",
-#'   end_date = "2011-02-01"
+#'   end_date = "2011-02-01",
+#'   limit = FALSE
 #' )
 #'
 #' # Get detections for a specific animal project at specific stations
-#' get_detections(con,
+#' get_detections(
+#'   con,
 #'   animal_project_code = "phd_reubens",
-#'   station_name = c("R03", "R05")
+#'   station_name = c("R03", "R05"),
+#'   limit = FALSE
 #' )
 #'
 #' # Get detections for a specific tag
-#' get_detections(con, tag_id = "A69-1303-65302")
+#' get_detections(
+#'   con,
+#'   tag_id = "A69-1303-65302",
+#'   limit = FALSE)
 #'
 #' # Get detections for a specific receiver during a specific time period
-#' get_detections(con,
-#'   receiver_id = "VR2W-122360", start_date = "2015-12-03",
-#'   end_date = "2015-12-05"
+#' get_detections(
+#'   con,
+#'   receiver_id = "VR2W-122360",
+#'   start_date = "2015-12-03",
+#'   end_date = "2015-12-05",
+#'   limit = FALSE
 #' )
 #' # Get detections for a specific species during a given period
-#' get_detections(con,
+#' get_detections(
+#'   con,
 #'   scientific_name = "Anguilla anguilla",
 #'   start_date = "2015-12-03",
-#'   end_date = "2015-12-05"
+#'   end_date = "2015-12-05",
+#'   limit = FALSE
 #' )
 #' }
 get_detections <- function(connection = con, network_project_code = NULL,
                            animal_project_code = NULL, start_date = NULL,
                            end_date = NULL, station_name = NULL,
                            tag_id = NULL, receiver_id = NULL,
-                           scientific_name = NULL, limit = NULL) {
+                           scientific_name = NULL, limit = TRUE) {
   # Check connection
   check_connection(connection)
 
@@ -146,11 +158,10 @@ get_detections <- function(connection = con, network_project_code = NULL,
   }
 
   # Check limit
-  if (is.null(limit)) {
-    limit_query <- glue_sql("LIMIT ALL", .con = connection)
+  if (limit) {
+    limit_query <- glue_sql("LIMIT 100", .con = connection)
   } else {
-    assert_that(is.number(limit))
-    limit_query <- glue_sql("LIMIT {as.character(limit)}", .con = connection)
+    limit_query <- glue_sql("LIMIT ALL}", .con = connection)
   }
 
   # Build query

--- a/R/get_detections.R
+++ b/R/get_detections.R
@@ -80,11 +80,16 @@
 #'   limit = FALSE
 #' )
 #' }
-get_detections <- function(connection = con, network_project_code = NULL,
-                           animal_project_code = NULL, start_date = NULL,
-                           end_date = NULL, station_name = NULL,
-                           tag_id = NULL, receiver_id = NULL,
-                           scientific_name = NULL, limit = TRUE) {
+get_detections <- function(connection = con,
+                           network_project_code = NULL,
+                           animal_project_code = NULL,
+                           start_date = NULL,
+                           end_date = NULL,
+                           station_name = NULL,
+                           tag_id = NULL,
+                           receiver_id = NULL,
+                           scientific_name = NULL,
+                           limit = TRUE) {
   # Check connection
   check_connection(connection)
 

--- a/R/get_detections.R
+++ b/R/get_detections.R
@@ -60,7 +60,8 @@
 #' get_detections(
 #'   con,
 #'   tag_id = "A69-1303-65302",
-#'   limit = FALSE)
+#'   limit = FALSE
+#' )
 #'
 #' # Get detections for a specific receiver during a specific time period
 #' get_detections(

--- a/R/get_detections.R
+++ b/R/get_detections.R
@@ -67,7 +67,7 @@
 #'   end_date = "2015-12-05"
 #' )
 #' }
-get_detections <- function(connection, network_project_code = NULL,
+get_detections <- function(connection = con, network_project_code = NULL,
                            animal_project_code = NULL, start_date = NULL,
                            end_date = NULL, station_name = NULL,
                            tag_id = NULL, receiver_id = NULL,

--- a/R/get_projects.R
+++ b/R/get_projects.R
@@ -29,7 +29,8 @@
 #' # Get all network projects
 #' get_projects(con, project_type = "network")
 #' }
-get_projects <- function(connection = con, project_type = NULL) {
+get_projects <- function(connection = con,
+                         project_type = NULL) {
   # Check connection
   check_connection(connection)
 

--- a/R/get_projects.R
+++ b/R/get_projects.R
@@ -29,7 +29,7 @@
 #' # Get all network projects
 #' get_projects(con, project_type = "network")
 #' }
-get_projects <- function(connection, project_type = NULL) {
+get_projects <- function(connection = con, project_type = NULL) {
   # Check connection
   check_connection(connection)
 

--- a/R/get_receivers.R
+++ b/R/get_receivers.R
@@ -21,7 +21,7 @@
 #' # Get all receivers
 #' get_receivers(con)
 #' }
-get_receivers <- function(connection) {
+get_receivers <- function(connection = con) {
   # Check connection
   check_connection(connection)
 

--- a/R/get_receivers.R
+++ b/R/get_receivers.R
@@ -1,8 +1,9 @@
 #' Get receiver metadata
 #'
-#' Get metadata for receivers.
+#' Get metadata for receivers, with option to filter on receiver id.
 #'
 #' @param connection A valid connection to the ETN database.
+#' @param receiver_id (string) One or more receiver ids.
 #'
 #' @return A tibble (tidyverse data.frame).
 #'
@@ -20,14 +21,30 @@
 #'
 #' # Get all receivers
 #' get_receivers(con)
+#'
+#' # Get specific receivers
+#' get_receivers(con, receiver_id = "VR2-4842c")
+#' get_receivers(con, receiver_id = c("VR2AR-545719", "VR2AR-545720"))
 #' }
-get_receivers <- function(connection = con) {
+get_receivers <- function(connection = con,
+                          receiver_id = NULL) {
   # Check connection
   check_connection(connection)
+
+  # Check receiver_id
+  if (is.null(receiver_id)) {
+    receiver_id_query <- "True"
+  } else {
+    valid_receiver_ids <- list_receiver_ids(connection)
+    check_value(receiver_id, valid_receiver_ids, "receiver_id")
+    receiver_id_query <- glue_sql("receiver_id IN ({receiver_id*})", .con = connection)
+  }
 
   # Build query
   query <- glue_sql("
     SELECT * FROM vliz.receivers_view2
+    WHERE
+      {receiver_id_query}
     ", .con = connection)
   receivers <- dbGetQuery(connection, query)
   as_tibble(receivers)

--- a/R/get_tags.R
+++ b/R/get_tags.R
@@ -1,11 +1,11 @@
 #' Get tag metadata
 #'
-#' Get metadata for tags. Only returns tags that can be linked to an animal (and
-#' thus an animal project). By default, reference tags are excluded.
+#' Get metadata for tags, with option to filter on tag_id. By default, reference
+#' tags are excluded.
 #'
 #' @param connection A valid connection with the ETN database.
-#' @param animal_project_code (string) One or more animal projects.
-#' @param include_reference_tags (logical) Include reference tags. Default:
+#' @param tag_id (string) One or more tag ids.
+#' @param include_ref_tags (logical) Include reference tags. Default:
 #'   `FALSE`.
 #'
 #' @return A tibble (tidyverse data.frame).
@@ -26,43 +26,42 @@
 #' get_tags(con)
 #'
 #' # Get all tags, including reference tags
-#' get_tags(con, include_reference_tags = TRUE)
+#' get_tags(con, include_ref_tags = TRUE)
 #'
-#' # Get tags linked to specific animal project(s)
-#' get_tags(con, animal_project_code = "phd_reubens")
-#' get_tags(con, animal_project_code = c("phd_reubens", "2012_leopoldkanaal"))
+#' # Get specific tags (will automatically set include_ref_tags = TRUE)
+#' get_tags(con, tag_id = "A69-1303-65313")
+#' get_tags(con, tag_id = c("A69-1601-1705", "A69-1601-1707"))
 #' }
 get_tags <- function(connection = con,
-                     animal_project_code = NULL,
-                     include_reference_tags = FALSE) {
+                     tag_id = NULL,
+                     include_ref_tags = FALSE) {
   # Check connection
   check_connection(connection)
 
-  # Check animal_project_code
-  if (is.null(animal_project_code)) {
-    animal_project_code_query <- "True"
+  # Check tag_id
+  if (is.null(tag_id)) {
+    tag_id_query <- "True"
   } else {
-    valid_animal_project_codes <- list_animal_project_codes(connection)
-    check_value(animal_project_code, valid_animal_project_codes, "animal_project_code")
-    animal_project_code_query <- glue_sql("animal_project_code IN ({animal_project_code*})", .con = connection)
+    valid_tag_ids <- list_tag_ids(connection)
+    check_value(tag_id, valid_tag_ids, "tag_id")
+    tag_id_query <- glue_sql("tag_id IN ({tag_id*})", .con = connection)
+    include_ref_tags <- TRUE
   }
 
   # Build query
   query <- glue_sql("
-    SELECT tags.*
-    FROM vliz.tags_view2 AS tags
-      LEFT JOIN vliz.animals_view2 AS animals
-      ON animals.tag_fk = tags.pk
+    SELECT *
+    FROM vliz.tags_view2
     WHERE
-      {animal_project_code_query}
+      {tag_id_query}
     ", .con = connection)
   tags <- dbGetQuery(connection, query)
 
   # Filter on reference tags
-  if (include_reference_tags) {
+  if (include_ref_tags) {
     tags
   } else {
-    tags %>% filter(.data$type == "animal")
+    tags <- tags %>% filter(.data$type == "animal")
   }
 
   as_tibble(tags)

--- a/R/get_tags.R
+++ b/R/get_tags.R
@@ -1,6 +1,6 @@
 #' Get tag metadata
 #'
-#' Get metadata for tags, with option to filter on tag_id. By default, reference
+#' Get metadata for tags, with option to filter on tag id. By default, reference
 #' tags are excluded.
 #'
 #' @param connection A valid connection with the ETN database.

--- a/R/get_tags.R
+++ b/R/get_tags.R
@@ -32,7 +32,7 @@
 #' get_tags(con, animal_project_code = "phd_reubens")
 #' get_tags(con, animal_project_code = c("phd_reubens", "2012_leopoldkanaal"))
 #' }
-get_tags <- function(connection,
+get_tags <- function(connection = con,
                      animal_project_code = NULL,
                      include_reference_tags = FALSE) {
   # Check connection

--- a/R/list_animal_project_codes.R
+++ b/R/list_animal_project_codes.R
@@ -8,7 +8,7 @@
 #' @importFrom DBI dbGetQuery
 #'
 #' @return A vector of all unique `project_code` of `project_type="animal"` present in `projects`.
-list_animal_project_codes <- function(connection) {
+list_animal_project_codes <- function(connection = con) {
   query <- glue_sql("SELECT DISTINCT project_code FROM vliz.projects_view2 WHERE project_type = 'animal'",
     .con = connection
   )

--- a/R/list_network_project_codes.R
+++ b/R/list_network_project_codes.R
@@ -8,7 +8,7 @@
 #' @importFrom DBI dbGetQuery
 #'
 #' @return A vector of all unique `project_code` of `project_type="network"` present in `projects`.
-list_network_project_codes <- function(connection) {
+list_network_project_codes <- function(connection = con) {
   query <- glue_sql("SELECT DISTINCT project_code FROM vliz.projects_view2 WHERE project_type = 'network'",
     .con = connection
   )

--- a/R/list_receiver_ids.R
+++ b/R/list_receiver_ids.R
@@ -8,7 +8,7 @@
 #' @importFrom DBI dbGetQuery
 #'
 #' @return A vector of all unique `receiver_id` present in `receivers`.
-list_receiver_ids <- function(connection) {
+list_receiver_ids <- function(connection = con) {
   query <- glue_sql("SELECT DISTINCT receiver_id FROM vliz.receivers_view2",
     .con = connection
   )

--- a/R/list_scientific_names.R
+++ b/R/list_scientific_names.R
@@ -8,7 +8,7 @@
 #' @importFrom DBI dbGetQuery
 #'
 #' @return A vector of all unique `scientific_name` present in `animals`.
-list_scientific_names <- function(connection) {
+list_scientific_names <- function(connection = con) {
   query <- glue_sql("SELECT DISTINCT scientific_name FROM vliz.animals_view2",
     .con = connection
   )

--- a/R/list_station_names.R
+++ b/R/list_station_names.R
@@ -8,7 +8,7 @@
 #' @importFrom DBI dbGetQuery
 #'
 #' @return A vector of all unique `station_name` present in `deployments`.
-list_station_names <- function(connection) {
+list_station_names <- function(connection = con) {
   query <- glue_sql("SELECT DISTINCT station_name FROM vliz.deployments_view2",
     .con = connection
   )

--- a/R/list_tag_ids.R
+++ b/R/list_tag_ids.R
@@ -8,7 +8,7 @@
 #' @importFrom DBI dbGetQuery
 #'
 #' @return A vector of all unique `tag_id` present in `tags`.
-list_tag_ids <- function(connection) {
+list_tag_ids <- function(connection = con) {
   query <- glue_sql("SELECT DISTINCT tag_id FROM vliz.tags_view2",
     .con = connection
   )

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,7 +13,7 @@
 #' @keywords internal
 check_connection <- function(connection) {
   assert_that(is(connection, "PostgreSQL"),
-              msg = "Not a connection object to database."
+    msg = "Not a connection object to database."
   )
   assert_that(connection@info$dbname == "ETN")
 }
@@ -65,7 +65,7 @@ check_value <- function(arg, options = NULL, arg_name) {
     assert_that(
       all(arg %in% options),
       msg = glue(
-        "Not valid input value(s) for {arg_name} input argument.
+        "Invalid value(s) for {arg_name} argument.
         Valid inputs are: {options_to_print*}.",
         .transformer = collapse_transformer(
           sep = ", ",
@@ -130,7 +130,7 @@ check_date_time <- function(date_time, date_name = "start_date") {
       if (grepl("No formats found", warning$message)) {
         stop(glue(
           "The given {date_name}, {date_time}, is not in a valid ",
-          "date format. Use a ymd format or shorter, ",
+          "date format. Use a yyyy-mm-dd format or shorter, ",
           "e.g. 2012-11-21, 2012-11 or 2012."
         ))
       } else {

--- a/docs/404.html
+++ b/docs/404.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="https://inbo.github.io/etn/index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 

--- a/docs/CODE_OF_CONDUCT.html
+++ b/docs/CODE_OF_CONDUCT.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 

--- a/docs/CONTRIBUTING.html
+++ b/docs/CONTRIBUTING.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 

--- a/docs/articles/etn.html
+++ b/docs/articles/etn.html
@@ -38,7 +38,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -80,7 +80,7 @@
       <h1>Access ETN data using the etn R package</h1>
                         <h4 class="author">Stijn Van Hoey</h4>
             
-            <h4 class="date">2020-02-21</h4>
+            <h4 class="date">2020-02-26</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/inbo/etn/blob/master/vignettes/etn.Rmd"><code>vignettes/etn.Rmd</code></a></small>
       <div class="hidden name"><code>etn.Rmd</code></div>
@@ -103,8 +103,7 @@
 <h2 class="hasAnchor">
 <a href="#the-database-connection" class="anchor"></a>The database connection</h2>
 <p>In order to access the data, the first step is always to connect with your user credentials (as received by VLIZ) to the database.</p>
-<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1">my_con &lt;-<span class="st"> </span><span class="kw"><a href="../reference/connect_to_etn.html">connect_to_etn</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/Sys.getenv.html">Sys.getenv</a></span>(<span class="st">"userid"</span>),</a>
-<a class="sourceLine" id="cb3-2" data-line-number="2">                         <span class="kw"><a href="https://rdrr.io/r/base/Sys.getenv.html">Sys.getenv</a></span>(<span class="st">"pwd"</span>))</a></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1">con &lt;-<span class="st"> </span><span class="kw"><a href="../reference/connect_to_etn.html">connect_to_etn</a></span>(<span class="kw"><a href="https://rdrr.io/r/base/Sys.getenv.html">Sys.getenv</a></span>(<span class="st">"userid"</span>), <span class="kw"><a href="https://rdrr.io/r/base/Sys.getenv.html">Sys.getenv</a></span>(<span class="st">"pwd"</span>))</a></code></pre></div>
 <p>Remark that for this example, we <a href="http://db.rstudio.com/best-practices/managing-credentials/#use-environment-variables">load the user credentials as environmental variables</a> by saving an <code>.Renviron</code> file in the home directory with the username and password stored. Other options are available as well, as explained <a href="http://db.rstudio.com/best-practices/managing-credentials/">here</a>.</p>
 <p>Once the connection established, the <code>get_*</code> functions can be used to effectively access the data. Each of these functions have a (valid database) connection as first input.</p>
 <p>Notice, that you can find the <code>get_*</code>-functions inside Rstudio by typing: <code>etn::get_*</code> + TAB button.</p>
@@ -116,75 +115,103 @@
 <h3 class="hasAnchor">
 <a href="#project-overview" class="anchor"></a>Project overview</h3>
 <p>To get a full overview of the projects you have access to, use the function <code><a href="../reference/get_projects.html">get_projects()</a></code>:</p>
-<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1">my_projects &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_projects.html">get_projects</a></span>(my_con)</a>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1">my_projects &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_projects.html">get_projects</a></span>(con)</a>
 <a class="sourceLine" id="cb4-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(my_projects, <span class="dv">10</span>) <span class="co"># print 10 first</span></a>
-<a class="sourceLine" id="cb4-3" data-line-number="3"><span class="co">#&gt; # A tibble: 10 x 12</span></a>
-<a class="sourceLine" id="cb4-4" data-line-number="4"><span class="co">#&gt;       id name  projectcode type  startdate  enddate    moratorium</span></a>
-<a class="sourceLine" id="cb4-5" data-line-number="5"><span class="co">#&gt;    &lt;int&gt; &lt;chr&gt; &lt;chr&gt;       &lt;chr&gt; &lt;date&gt;     &lt;date&gt;     &lt;chr&gt;     </span></a>
-<a class="sourceLine" id="cb4-6" data-line-number="6"><span class="co">#&gt;  1   638 "Lif… cpod-lifew… netw… NA         NA         0         </span></a>
-<a class="sourceLine" id="cb4-7" data-line-number="7"><span class="co">#&gt;  2     3 "Lif… lifewatch   netw… NA         NA         0         </span></a>
-<a class="sourceLine" id="cb4-8" data-line-number="8"><span class="co">#&gt;  3   609 "NON… none        netw… NA         NA         1         </span></a>
-<a class="sourceLine" id="cb4-9" data-line-number="9"><span class="co">#&gt;  4   611 "Tes… testvr2ar   netw… NA         NA         1         </span></a>
-<a class="sourceLine" id="cb4-10" data-line-number="10"><span class="co">#&gt;  5   608 ""    no_info     netw… NA         NA         1         </span></a>
-<a class="sourceLine" id="cb4-11" data-line-number="11"><span class="co">#&gt;  6   598 "Del… driederfzi… anim… NA         NA         1         </span></a>
-<a class="sourceLine" id="cb4-12" data-line-number="12"><span class="co">#&gt;  7   594 "Del… duurswold   anim… NA         NA         1         </span></a>
-<a class="sourceLine" id="cb4-13" data-line-number="13"><span class="co">#&gt;  8   603 "Gar… gamerwolde  anim… NA         NA         1         </span></a>
-<a class="sourceLine" id="cb4-14" data-line-number="14"><span class="co">#&gt;  9   595 "Ams… amsterdam   anim… NA         NA         1         </span></a>
-<a class="sourceLine" id="cb4-15" data-line-number="15"><span class="co">#&gt; 10   591 "Hun… hunze       anim… NA         NA         1         </span></a>
-<a class="sourceLine" id="cb4-16" data-line-number="16"><span class="co">#&gt; # … with 5 more variables: imis_dataset_id &lt;int&gt;, context_type &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb4-17" data-line-number="17"><span class="co">#&gt; #   latitude &lt;dbl&gt;, longitude &lt;dbl&gt;, telemtry_type &lt;chr&gt;</span></a></code></pre></div>
+<a class="sourceLine" id="cb4-3" data-line-number="3"><span class="co">#&gt; # A tibble: 10 x 13</span></a>
+<a class="sourceLine" id="cb4-4" data-line-number="4"><span class="co">#&gt;       pk project_code project_type context_type telemetry_type project_name</span></a>
+<a class="sourceLine" id="cb4-5" data-line-number="5"><span class="co">#&gt;    &lt;int&gt; &lt;chr&gt;        &lt;chr&gt;        &lt;chr&gt;        &lt;chr&gt;          &lt;chr&gt;       </span></a>
+<a class="sourceLine" id="cb4-6" data-line-number="6"><span class="co">#&gt;  1   638 cpod-lifewa… network      cpod         &lt;NA&gt;           Lifewatch   </span></a>
+<a class="sourceLine" id="cb4-7" data-line-number="7"><span class="co">#&gt;  2     3 lifewatch    network      acoustic_te… &lt;NA&gt;           Lifewatch   </span></a>
+<a class="sourceLine" id="cb4-8" data-line-number="8"><span class="co">#&gt;  3   611 testvr2ar    network      acoustic_te… &lt;NA&gt;           Test VR2AR  </span></a>
+<a class="sourceLine" id="cb4-9" data-line-number="9"><span class="co">#&gt;  4   596 flatfish     animal       acoustic_te… &lt;NA&gt;           Flatfish    </span></a>
+<a class="sourceLine" id="cb4-10" data-line-number="10"><span class="co">#&gt;  5   617 pc4c         network      acoustic_te… &lt;NA&gt;           PC4C        </span></a>
+<a class="sourceLine" id="cb4-11" data-line-number="11"><span class="co">#&gt;  6   625 Deveron      network      acoustic_te… &lt;NA&gt;           Deveron 2016</span></a>
+<a class="sourceLine" id="cb4-12" data-line-number="12"><span class="co">#&gt;  7   626 MorayFirth   network      acoustic_te… &lt;NA&gt;           Moray Firth…</span></a>
+<a class="sourceLine" id="cb4-13" data-line-number="13"><span class="co">#&gt;  8   627 Aberdeen     network      acoustic_te… &lt;NA&gt;           Aberdeen 20…</span></a>
+<a class="sourceLine" id="cb4-14" data-line-number="14"><span class="co">#&gt;  9   606 codnoise     animal       acoustic_te… &lt;NA&gt;           CodNoise    </span></a>
+<a class="sourceLine" id="cb4-15" data-line-number="15"><span class="co">#&gt; 10   628 Conon        network      acoustic_te… &lt;NA&gt;           Conon 2017  </span></a>
+<a class="sourceLine" id="cb4-16" data-line-number="16"><span class="co">#&gt; # … with 7 more variables: principal_investigator &lt;chr&gt;, start_date &lt;date&gt;,</span></a>
+<a class="sourceLine" id="cb4-17" data-line-number="17"><span class="co">#&gt; #   end_date &lt;date&gt;, latitude &lt;dbl&gt;, longitude &lt;dbl&gt;, moratorium &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb4-18" data-line-number="18"><span class="co">#&gt; #   imis_dataset_id &lt;int&gt;</span></a></code></pre></div>
 <p>As projects are defined both on the level of the <code>animal</code> as well as the <code>network</code>, a column <code>type</code> is available that defines the type of project (<code>animal</code> or <code>network</code>). Still, one can also directly subset by adding the type as input argument, e.g. for network:</p>
-<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1">my_network_projects &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_projects.html">get_projects</a></span>(my_con, <span class="dt">project_type =</span> <span class="st">"network"</span>)</a>
+<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1">my_network_projects &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_projects.html">get_projects</a></span>(con, <span class="dt">project_type =</span> <span class="st">"network"</span>)</a>
 <a class="sourceLine" id="cb5-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(my_network_projects, <span class="dv">10</span>) <span class="co"># print 10 first</span></a>
-<a class="sourceLine" id="cb5-3" data-line-number="3"><span class="co">#&gt; # A tibble: 10 x 12</span></a>
-<a class="sourceLine" id="cb5-4" data-line-number="4"><span class="co">#&gt;       id name  projectcode type  startdate  enddate    moratorium</span></a>
-<a class="sourceLine" id="cb5-5" data-line-number="5"><span class="co">#&gt;    &lt;int&gt; &lt;chr&gt; &lt;chr&gt;       &lt;chr&gt; &lt;date&gt;     &lt;date&gt;     &lt;chr&gt;     </span></a>
-<a class="sourceLine" id="cb5-6" data-line-number="6"><span class="co">#&gt;  1   638 "Lif… cpod-lifew… netw… NA         NA         0         </span></a>
-<a class="sourceLine" id="cb5-7" data-line-number="7"><span class="co">#&gt;  2     3 "Lif… lifewatch   netw… NA         NA         0         </span></a>
-<a class="sourceLine" id="cb5-8" data-line-number="8"><span class="co">#&gt;  3   609 "NON… none        netw… NA         NA         1         </span></a>
-<a class="sourceLine" id="cb5-9" data-line-number="9"><span class="co">#&gt;  4   611 "Tes… testvr2ar   netw… NA         NA         1         </span></a>
-<a class="sourceLine" id="cb5-10" data-line-number="10"><span class="co">#&gt;  5   608 ""    no_info     netw… NA         NA         1         </span></a>
-<a class="sourceLine" id="cb5-11" data-line-number="11"><span class="co">#&gt;  6   617 "PC4… pc4c        netw… 2017-07-03 NA         0         </span></a>
-<a class="sourceLine" id="cb5-12" data-line-number="12"><span class="co">#&gt;  7   625 "Dev… Deveron     netw… 2016-04-01 2016-07-01 0         </span></a>
-<a class="sourceLine" id="cb5-13" data-line-number="13"><span class="co">#&gt;  8   626 "Mor… MorayFirth  netw… 2016-04-01 2016-07-01 0         </span></a>
-<a class="sourceLine" id="cb5-14" data-line-number="14"><span class="co">#&gt;  9   627 "Abe… Aberdeen    netw… 2017-08-01 2017-12-22 0         </span></a>
-<a class="sourceLine" id="cb5-15" data-line-number="15"><span class="co">#&gt; 10   628 "Con… Conon       netw… 2016-04-01 2016-07-01 0         </span></a>
-<a class="sourceLine" id="cb5-16" data-line-number="16"><span class="co">#&gt; # … with 5 more variables: imis_dataset_id &lt;int&gt;, context_type &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb5-17" data-line-number="17"><span class="co">#&gt; #   latitude &lt;dbl&gt;, longitude &lt;dbl&gt;, telemtry_type &lt;chr&gt;</span></a></code></pre></div>
+<a class="sourceLine" id="cb5-3" data-line-number="3"><span class="co">#&gt; # A tibble: 10 x 13</span></a>
+<a class="sourceLine" id="cb5-4" data-line-number="4"><span class="co">#&gt;       pk project_code project_type context_type telemetry_type project_name</span></a>
+<a class="sourceLine" id="cb5-5" data-line-number="5"><span class="co">#&gt;    &lt;int&gt; &lt;chr&gt;        &lt;chr&gt;        &lt;chr&gt;        &lt;chr&gt;          &lt;chr&gt;       </span></a>
+<a class="sourceLine" id="cb5-6" data-line-number="6"><span class="co">#&gt;  1   638 cpod-lifewa… network      cpod         &lt;NA&gt;           Lifewatch   </span></a>
+<a class="sourceLine" id="cb5-7" data-line-number="7"><span class="co">#&gt;  2     3 lifewatch    network      acoustic_te… &lt;NA&gt;           Lifewatch   </span></a>
+<a class="sourceLine" id="cb5-8" data-line-number="8"><span class="co">#&gt;  3   611 testvr2ar    network      acoustic_te… &lt;NA&gt;           Test VR2AR  </span></a>
+<a class="sourceLine" id="cb5-9" data-line-number="9"><span class="co">#&gt;  4   617 pc4c         network      acoustic_te… &lt;NA&gt;           PC4C        </span></a>
+<a class="sourceLine" id="cb5-10" data-line-number="10"><span class="co">#&gt;  5   625 Deveron      network      acoustic_te… &lt;NA&gt;           Deveron 2016</span></a>
+<a class="sourceLine" id="cb5-11" data-line-number="11"><span class="co">#&gt;  6   626 MorayFirth   network      acoustic_te… &lt;NA&gt;           Moray Firth…</span></a>
+<a class="sourceLine" id="cb5-12" data-line-number="12"><span class="co">#&gt;  7   627 Aberdeen     network      acoustic_te… &lt;NA&gt;           Aberdeen 20…</span></a>
+<a class="sourceLine" id="cb5-13" data-line-number="13"><span class="co">#&gt;  8   628 Conon        network      acoustic_te… &lt;NA&gt;           Conon 2017  </span></a>
+<a class="sourceLine" id="cb5-14" data-line-number="14"><span class="co">#&gt;  9   629 Skye         network      acoustic_te… &lt;NA&gt;           Skye 2017   </span></a>
+<a class="sourceLine" id="cb5-15" data-line-number="15"><span class="co">#&gt; 10    13 maas         network      acoustic_te… &lt;NA&gt;           Maas        </span></a>
+<a class="sourceLine" id="cb5-16" data-line-number="16"><span class="co">#&gt; # … with 7 more variables: principal_investigator &lt;chr&gt;, start_date &lt;date&gt;,</span></a>
+<a class="sourceLine" id="cb5-17" data-line-number="17"><span class="co">#&gt; #   end_date &lt;date&gt;, latitude &lt;dbl&gt;, longitude &lt;dbl&gt;, moratorium &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb5-18" data-line-number="18"><span class="co">#&gt; #   imis_dataset_id &lt;int&gt;</span></a></code></pre></div>
 </div>
 <div id="receiver-overview" class="section level3">
 <h3 class="hasAnchor">
 <a href="#receiver-overview" class="anchor"></a>Receiver overview</h3>
-<p>A network project typically considers multiple receivers that are placed on specific locations to lay out the network. To get an overview of the receivers or those linked to specific projects, use the <code>get_receivers</code> function:</p>
-<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">ws3_receivers &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_receivers.html">get_receivers</a></span>(my_con, <span class="dt">network_project_code =</span> <span class="st">"ws3"</span>)</a>
-<a class="sourceLine" id="cb6-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(ws3_receivers, <span class="dv">10</span>) <span class="co"># print 10 first</span></a>
-<a class="sourceLine" id="cb6-3" data-line-number="3"><span class="co">#&gt; # A tibble: 0 x 27</span></a>
-<a class="sourceLine" id="cb6-4" data-line-number="4"><span class="co">#&gt; # … with 27 variables: pk &lt;int&gt;, receiver_id &lt;chr&gt;, application_type &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb6-5" data-line-number="5"><span class="co">#&gt; #   network_project_code &lt;chr&gt;, telemetry_type &lt;chr&gt;, manufacturer &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb6-6" data-line-number="6"><span class="co">#&gt; #   receiver_id_model &lt;chr&gt;, receiver_id_serial_number &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb6-7" data-line-number="7"><span class="co">#&gt; #   modem_address &lt;chr&gt;, status &lt;chr&gt;, battery_estimated_life &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb6-8" data-line-number="8"><span class="co">#&gt; #   owner_organization &lt;chr&gt;, financing_project &lt;chr&gt;, built_in_tag_id &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb6-9" data-line-number="9"><span class="co">#&gt; #   ar_model_number &lt;chr&gt;, ar_serial_number &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb6-10" data-line-number="10"><span class="co">#&gt; #   ar_battery_estimated_life &lt;chr&gt;, ar_voltage_at_deploy &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb6-11" data-line-number="11"><span class="co">#&gt; #   ar_interrogate_code &lt;chr&gt;, ar_receive_frequency &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb6-12" data-line-number="12"><span class="co">#&gt; #   ar_reply_frequency &lt;chr&gt;, ar_ping_rate &lt;chr&gt;, ar_enable_code_address &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb6-13" data-line-number="13"><span class="co">#&gt; #   ar_release_code &lt;chr&gt;, ar_disable_code &lt;chr&gt;, ar_tilt_code &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb6-14" data-line-number="14"><span class="co">#&gt; #   ar_tilt_after_deploy &lt;chr&gt;</span></a></code></pre></div>
+<p>A network project typically considers multiple receivers that are placed on specific locations to lay out the network. To get an overview of receivers deployments linked to specific projects, use the <code>get_deployments</code> function:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">ws3_deployments &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_deployments.html">get_deployments</a></span>(con, <span class="dt">network_project_code =</span> <span class="st">"ws3"</span>)</a>
+<a class="sourceLine" id="cb6-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(ws3_deployments, <span class="dv">10</span>) <span class="co"># print 10 first</span></a>
+<a class="sourceLine" id="cb6-3" data-line-number="3"><span class="co">#&gt; # A tibble: 6 x 39</span></a>
+<a class="sourceLine" id="cb6-4" data-line-number="4"><span class="co">#&gt;      pk receiver_id network_project… station_name station_descrip…</span></a>
+<a class="sourceLine" id="cb6-5" data-line-number="5"><span class="co">#&gt;   &lt;int&gt; &lt;chr&gt;       &lt;chr&gt;            &lt;chr&gt;        &lt;chr&gt;           </span></a>
+<a class="sourceLine" id="cb6-6" data-line-number="6"><span class="co">#&gt; 1  6173 VR2W-127731 ws3              ws-53A       53A             </span></a>
+<a class="sourceLine" id="cb6-7" data-line-number="7"><span class="co">#&gt; 2  6177 VR2W-127725 ws3              ws-HW6       ws_HW6          </span></a>
+<a class="sourceLine" id="cb6-8" data-line-number="8"><span class="co">#&gt; 3  6178 VR2W-127735 ws3              ws-42A       42A             </span></a>
+<a class="sourceLine" id="cb6-9" data-line-number="9"><span class="co">#&gt; 4  6179 VR2W-127734 ws3              ws-55        55              </span></a>
+<a class="sourceLine" id="cb6-10" data-line-number="10"><span class="co">#&gt; 5  6180 VR2W-127737 ws3              ws-53        53              </span></a>
+<a class="sourceLine" id="cb6-11" data-line-number="11"><span class="co">#&gt; 6  6182 VR2W-115439 ws3              ws-F42       F42             </span></a>
+<a class="sourceLine" id="cb6-12" data-line-number="12"><span class="co">#&gt; # … with 34 more variables: station_manager &lt;chr&gt;, deploy_date_time &lt;dttm&gt;,</span></a>
+<a class="sourceLine" id="cb6-13" data-line-number="13"><span class="co">#&gt; #   deploy_latitude &lt;dbl&gt;, deploy_longitude &lt;dbl&gt;, intended_latitude &lt;dbl&gt;,</span></a>
+<a class="sourceLine" id="cb6-14" data-line-number="14"><span class="co">#&gt; #   intended_longitude &lt;dbl&gt;, mooring_type &lt;chr&gt;, bottom_depth &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb6-15" data-line-number="15"><span class="co">#&gt; #   riser_length &lt;chr&gt;, deploy_depth &lt;chr&gt;, battery_installation_date &lt;dttm&gt;,</span></a>
+<a class="sourceLine" id="cb6-16" data-line-number="16"><span class="co">#&gt; #   battery_estimated_end_date &lt;dttm&gt;, activation_date_time &lt;dttm&gt;,</span></a>
+<a class="sourceLine" id="cb6-17" data-line-number="17"><span class="co">#&gt; #   recover_date_time &lt;dttm&gt;, recover_latitude &lt;dbl&gt;, recover_longitude &lt;dbl&gt;,</span></a>
+<a class="sourceLine" id="cb6-18" data-line-number="18"><span class="co">#&gt; #   download_date_time &lt;dttm&gt;, download_file_name &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb6-19" data-line-number="19"><span class="co">#&gt; #   valid_data_until_date_time &lt;dttm&gt;, sync_date_time &lt;dttm&gt;, time_drift &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb6-20" data-line-number="20"><span class="co">#&gt; #   ar_battery_installation_date &lt;dttm&gt;, ar_confirm &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb6-21" data-line-number="21"><span class="co">#&gt; #   transmit_profile &lt;chr&gt;, transmit_power_output &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb6-22" data-line-number="22"><span class="co">#&gt; #   log_temperature_stats_period &lt;int&gt;, log_temperature_sample_period &lt;int&gt;,</span></a>
+<a class="sourceLine" id="cb6-23" data-line-number="23"><span class="co">#&gt; #   log_tilt_sample_period &lt;int&gt;, log_noise_stats_period &lt;int&gt;,</span></a>
+<a class="sourceLine" id="cb6-24" data-line-number="24"><span class="co">#&gt; #   log_noise_sample_period &lt;int&gt;, log_depth_stats_period &lt;int&gt;,</span></a>
+<a class="sourceLine" id="cb6-25" data-line-number="25"><span class="co">#&gt; #   log_depth_sample_period &lt;int&gt;, comments &lt;chr&gt;, receiver_status &lt;chr&gt;</span></a></code></pre></div>
 <p>You can also define multiple (network) projects at the same time, by combining them in a vector:</p>
-<div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" data-line-number="1">ws_receivers &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_receivers.html">get_receivers</a></span>(my_con, <span class="dt">network_project_code =</span> <span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"ws1"</span>, <span class="st">"ws3"</span>))</a>
-<a class="sourceLine" id="cb7-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(ws_receivers, <span class="dv">10</span>) <span class="co"># print 10 first</span></a>
-<a class="sourceLine" id="cb7-3" data-line-number="3"><span class="co">#&gt; # A tibble: 0 x 27</span></a>
-<a class="sourceLine" id="cb7-4" data-line-number="4"><span class="co">#&gt; # … with 27 variables: pk &lt;int&gt;, receiver_id &lt;chr&gt;, application_type &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb7-5" data-line-number="5"><span class="co">#&gt; #   network_project_code &lt;chr&gt;, telemetry_type &lt;chr&gt;, manufacturer &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb7-6" data-line-number="6"><span class="co">#&gt; #   receiver_id_model &lt;chr&gt;, receiver_id_serial_number &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb7-7" data-line-number="7"><span class="co">#&gt; #   modem_address &lt;chr&gt;, status &lt;chr&gt;, battery_estimated_life &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb7-8" data-line-number="8"><span class="co">#&gt; #   owner_organization &lt;chr&gt;, financing_project &lt;chr&gt;, built_in_tag_id &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb7-9" data-line-number="9"><span class="co">#&gt; #   ar_model_number &lt;chr&gt;, ar_serial_number &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb7-10" data-line-number="10"><span class="co">#&gt; #   ar_battery_estimated_life &lt;chr&gt;, ar_voltage_at_deploy &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb7-11" data-line-number="11"><span class="co">#&gt; #   ar_interrogate_code &lt;chr&gt;, ar_receive_frequency &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb7-12" data-line-number="12"><span class="co">#&gt; #   ar_reply_frequency &lt;chr&gt;, ar_ping_rate &lt;chr&gt;, ar_enable_code_address &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb7-13" data-line-number="13"><span class="co">#&gt; #   ar_release_code &lt;chr&gt;, ar_disable_code &lt;chr&gt;, ar_tilt_code &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb7-14" data-line-number="14"><span class="co">#&gt; #   ar_tilt_after_deploy &lt;chr&gt;</span></a></code></pre></div>
+<div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" data-line-number="1">ws_deployments &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_deployments.html">get_deployments</a></span>(con, <span class="dt">network_project_code =</span> <span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"ws1"</span>, <span class="st">"ws3"</span>))</a>
+<a class="sourceLine" id="cb7-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(ws_deployments, <span class="dv">10</span>) <span class="co"># print 10 first</span></a>
+<a class="sourceLine" id="cb7-3" data-line-number="3"><span class="co">#&gt; # A tibble: 10 x 39</span></a>
+<a class="sourceLine" id="cb7-4" data-line-number="4"><span class="co">#&gt;       pk receiver_id network_project… station_name station_descrip…</span></a>
+<a class="sourceLine" id="cb7-5" data-line-number="5"><span class="co">#&gt;    &lt;int&gt; &lt;chr&gt;       &lt;chr&gt;            &lt;chr&gt;        &lt;chr&gt;           </span></a>
+<a class="sourceLine" id="cb7-6" data-line-number="6"><span class="co">#&gt;  1  3978 VR2W-123826 ws1              ws-W7        W7              </span></a>
+<a class="sourceLine" id="cb7-7" data-line-number="7"><span class="co">#&gt;  2  6020 VR2W-123815 ws1              ws-W6        W-6             </span></a>
+<a class="sourceLine" id="cb7-8" data-line-number="8"><span class="co">#&gt;  3  6026 VR2W-123832 ws1              ws-OG10      OG-10           </span></a>
+<a class="sourceLine" id="cb7-9" data-line-number="9"><span class="co">#&gt;  4  6029 VR2Tx-4807… ws1              ws-W7        W7              </span></a>
+<a class="sourceLine" id="cb7-10" data-line-number="10"><span class="co">#&gt;  5  6030 VR2Tx-4800… ws1              ws-WN2       WN-2            </span></a>
+<a class="sourceLine" id="cb7-11" data-line-number="11"><span class="co">#&gt;  6  6032 VR2Tx-4807… ws1              ws-DL12      DL-12           </span></a>
+<a class="sourceLine" id="cb7-12" data-line-number="12"><span class="co">#&gt;  7  6033 VR2W-123831 ws1              ws-OGDL      OGDL            </span></a>
+<a class="sourceLine" id="cb7-13" data-line-number="13"><span class="co">#&gt;  8  6036 VR2W-123819 ws1              ws-SP3       SP-2            </span></a>
+<a class="sourceLine" id="cb7-14" data-line-number="14"><span class="co">#&gt;  9  6038 VR2W-123821 ws1              ws-GVWSP     GVW-SP          </span></a>
+<a class="sourceLine" id="cb7-15" data-line-number="15"><span class="co">#&gt; 10  6039 VR2W-131002 ws1              ws-TRAWL     TRAWL           </span></a>
+<a class="sourceLine" id="cb7-16" data-line-number="16"><span class="co">#&gt; # … with 34 more variables: station_manager &lt;chr&gt;, deploy_date_time &lt;dttm&gt;,</span></a>
+<a class="sourceLine" id="cb7-17" data-line-number="17"><span class="co">#&gt; #   deploy_latitude &lt;dbl&gt;, deploy_longitude &lt;dbl&gt;, intended_latitude &lt;dbl&gt;,</span></a>
+<a class="sourceLine" id="cb7-18" data-line-number="18"><span class="co">#&gt; #   intended_longitude &lt;dbl&gt;, mooring_type &lt;chr&gt;, bottom_depth &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb7-19" data-line-number="19"><span class="co">#&gt; #   riser_length &lt;chr&gt;, deploy_depth &lt;chr&gt;, battery_installation_date &lt;dttm&gt;,</span></a>
+<a class="sourceLine" id="cb7-20" data-line-number="20"><span class="co">#&gt; #   battery_estimated_end_date &lt;dttm&gt;, activation_date_time &lt;dttm&gt;,</span></a>
+<a class="sourceLine" id="cb7-21" data-line-number="21"><span class="co">#&gt; #   recover_date_time &lt;dttm&gt;, recover_latitude &lt;dbl&gt;, recover_longitude &lt;dbl&gt;,</span></a>
+<a class="sourceLine" id="cb7-22" data-line-number="22"><span class="co">#&gt; #   download_date_time &lt;dttm&gt;, download_file_name &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb7-23" data-line-number="23"><span class="co">#&gt; #   valid_data_until_date_time &lt;dttm&gt;, sync_date_time &lt;dttm&gt;, time_drift &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb7-24" data-line-number="24"><span class="co">#&gt; #   ar_battery_installation_date &lt;dttm&gt;, ar_confirm &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb7-25" data-line-number="25"><span class="co">#&gt; #   transmit_profile &lt;chr&gt;, transmit_power_output &lt;chr&gt;,</span></a>
+<a class="sourceLine" id="cb7-26" data-line-number="26"><span class="co">#&gt; #   log_temperature_stats_period &lt;int&gt;, log_temperature_sample_period &lt;int&gt;,</span></a>
+<a class="sourceLine" id="cb7-27" data-line-number="27"><span class="co">#&gt; #   log_tilt_sample_period &lt;int&gt;, log_noise_stats_period &lt;int&gt;,</span></a>
+<a class="sourceLine" id="cb7-28" data-line-number="28"><span class="co">#&gt; #   log_noise_sample_period &lt;int&gt;, log_depth_stats_period &lt;int&gt;,</span></a>
+<a class="sourceLine" id="cb7-29" data-line-number="29"><span class="co">#&gt; #   log_depth_sample_period &lt;int&gt;, comments &lt;chr&gt;, receiver_status &lt;chr&gt;</span></a></code></pre></div>
 <p>When a number of columns is not useful to your specific purpose, remember that the output is a <code>data.frame</code>, which can be filtered and subsetted conveniently with for example the <a href="http://dplyr.tidyverse.org/">dplyr</a> functions.</p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb8-1" data-line-number="1"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span>(dplyr)</a>
 <a class="sourceLine" id="cb8-2" data-line-number="2"><span class="co">#&gt; </span></a>
@@ -196,18 +223,28 @@
 <a class="sourceLine" id="cb8-8" data-line-number="8"><span class="co">#&gt; </span></a>
 <a class="sourceLine" id="cb8-9" data-line-number="9"><span class="co">#&gt;     intersect, setdiff, setequal, union</span></a></code></pre></div>
 <p>For example, selecting only the columns <code>serial_number</code>, <code>receiver</code> and <code>status</code>:</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1">ws_receivers <span class="op">%&gt;%</span><span class="st"> </span></a>
-<a class="sourceLine" id="cb9-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(receiver_id_serial_number, receiver_id, status) <span class="op">%&gt;%</span></a>
+<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1">ws_deployments <span class="op">%&gt;%</span><span class="st"> </span></a>
+<a class="sourceLine" id="cb9-2" data-line-number="2"><span class="st">  </span><span class="kw"><a href="https://dplyr.tidyverse.org/reference/select.html">select</a></span>(receiver_id, receiver_status) <span class="op">%&gt;%</span></a>
 <a class="sourceLine" id="cb9-3" data-line-number="3"><span class="st">  </span><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(<span class="dv">10</span>)  <span class="co"># print 10 first</span></a>
-<a class="sourceLine" id="cb9-4" data-line-number="4"><span class="co">#&gt; # A tibble: 0 x 3</span></a>
-<a class="sourceLine" id="cb9-5" data-line-number="5"><span class="co">#&gt; # … with 3 variables: receiver_id_serial_number &lt;chr&gt;, receiver_id &lt;chr&gt;,</span></a>
-<a class="sourceLine" id="cb9-6" data-line-number="6"><span class="co">#&gt; #   status &lt;chr&gt;</span></a></code></pre></div>
+<a class="sourceLine" id="cb9-4" data-line-number="4"><span class="co">#&gt; # A tibble: 10 x 2</span></a>
+<a class="sourceLine" id="cb9-5" data-line-number="5"><span class="co">#&gt;    receiver_id  receiver_status</span></a>
+<a class="sourceLine" id="cb9-6" data-line-number="6"><span class="co">#&gt;    &lt;chr&gt;        &lt;chr&gt;          </span></a>
+<a class="sourceLine" id="cb9-7" data-line-number="7"><span class="co">#&gt;  1 VR2W-123826  Lost           </span></a>
+<a class="sourceLine" id="cb9-8" data-line-number="8"><span class="co">#&gt;  2 VR2W-123815  Active         </span></a>
+<a class="sourceLine" id="cb9-9" data-line-number="9"><span class="co">#&gt;  3 VR2W-123832  Active         </span></a>
+<a class="sourceLine" id="cb9-10" data-line-number="10"><span class="co">#&gt;  4 VR2Tx-480722 Active         </span></a>
+<a class="sourceLine" id="cb9-11" data-line-number="11"><span class="co">#&gt;  5 VR2Tx-480061 Active         </span></a>
+<a class="sourceLine" id="cb9-12" data-line-number="12"><span class="co">#&gt;  6 VR2Tx-480720 Active         </span></a>
+<a class="sourceLine" id="cb9-13" data-line-number="13"><span class="co">#&gt;  7 VR2W-123831  Active         </span></a>
+<a class="sourceLine" id="cb9-14" data-line-number="14"><span class="co">#&gt;  8 VR2W-123819  Active         </span></a>
+<a class="sourceLine" id="cb9-15" data-line-number="15"><span class="co">#&gt;  9 VR2W-123821  Available      </span></a>
+<a class="sourceLine" id="cb9-16" data-line-number="16"><span class="co">#&gt; 10 VR2W-131002  Active</span></a></code></pre></div>
 </div>
 <div id="deployments-overview" class="section level3">
 <h3 class="hasAnchor">
 <a href="#deployments-overview" class="anchor"></a>Deployments overview</h3>
 <p>Receivers are deployed for a specific period and this deployment information can be accessed as well with the command <code>get_deployments</code>. Filtering on the network project is similar to <code>get_receivers</code> and as the information about the receiver <code>status</code> is crucial, the function provides an additional argument to query based on the receiver status. Getting an overview of the lost and broken receivers of a specific project:</p>
-<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb10-1" data-line-number="1">my_deployments &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_deployments.html">get_deployments</a></span>(my_con, <span class="dt">network_project_code =</span> <span class="st">"ws1"</span>, </a>
+<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb10-1" data-line-number="1">my_deployments &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_deployments.html">get_deployments</a></span>(con, <span class="dt">network_project_code =</span> <span class="st">"ws1"</span>, </a>
 <a class="sourceLine" id="cb10-2" data-line-number="2">                                  <span class="dt">receiver_status =</span> <span class="kw"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"Broken"</span>, <span class="st">"Lost"</span>))</a>
 <a class="sourceLine" id="cb10-3" data-line-number="3"><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(my_deployments, <span class="dv">10</span>) <span class="co"># print 10 first </span></a>
 <a class="sourceLine" id="cb10-4" data-line-number="4"><span class="co">#&gt; # A tibble: 1 x 39</span></a>
@@ -234,7 +271,7 @@
 <a href="#animals-overview" class="anchor"></a>Animals overview</h3>
 <p>Within an animal project, multiple animals are provided with a transmitter. The metadata of these animals is requested with the function <code>get_animals</code>. As animals can be part of both network and animal projects, both can be used to filter the results.</p>
 <p>As such, selecting the animals metadata for the <code>2012_leopoldkanaal</code> project:</p>
-<div class="sourceCode" id="cb11"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb11-1" data-line-number="1">my_animals &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_animals.html">get_animals</a></span>(my_con, <span class="dt">animal_project_code =</span> <span class="st">"2012_leopoldkanaal"</span>)</a>
+<div class="sourceCode" id="cb11"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb11-1" data-line-number="1">my_animals &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_animals.html">get_animals</a></span>(con, <span class="dt">animal_project_code =</span> <span class="st">"2012_leopoldkanaal"</span>)</a>
 <a class="sourceLine" id="cb11-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(my_animals, <span class="dv">10</span>) <span class="co"># print 10 first</span></a>
 <a class="sourceLine" id="cb11-3" data-line-number="3"><span class="co">#&gt; # A tibble: 10 x 63</span></a>
 <a class="sourceLine" id="cb11-4" data-line-number="4"><span class="co">#&gt;       pk animal_id animal_project_… tag_id tag_fk scientific_name common_name</span></a>
@@ -270,7 +307,7 @@
 <a class="sourceLine" id="cb11-34" data-line-number="34"><span class="co">#&gt; #   pre_surgery_holding_period &lt;chr&gt;, post_surgery_holding_period &lt;chr&gt;,</span></a>
 <a class="sourceLine" id="cb11-35" data-line-number="35"><span class="co">#&gt; #   holding_temperature &lt;chr&gt;, comments &lt;chr&gt;</span></a></code></pre></div>
 <p>When interested in specific species, add the scientific name as argument.</p>
-<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb12-1" data-line-number="1">my_animals &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_animals.html">get_animals</a></span>(my_con, <span class="dt">animal_project_code =</span> <span class="st">"phd_reubens"</span>,</a>
+<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb12-1" data-line-number="1">my_animals &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_animals.html">get_animals</a></span>(con, <span class="dt">animal_project_code =</span> <span class="st">"phd_reubens"</span>,</a>
 <a class="sourceLine" id="cb12-2" data-line-number="2">                       <span class="dt">scientific_name =</span> <span class="st">"Sentinel"</span>)</a>
 <a class="sourceLine" id="cb12-3" data-line-number="3"><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(my_animals, <span class="dv">10</span>) <span class="co"># print 10 first</span></a>
 <a class="sourceLine" id="cb12-4" data-line-number="4"><span class="co">#&gt; # A tibble: 10 x 63</span></a>
@@ -311,22 +348,22 @@
 <div id="transmitter-overview" class="section level3">
 <h3 class="hasAnchor">
 <a href="#transmitter-overview" class="anchor"></a>Transmitter overview</h3>
-<p>The transmitters/tags metadata can be accessed by the <code>get_tags</code> function, with the option to subset on the animal project names:</p>
-<div class="sourceCode" id="cb13"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb13-1" data-line-number="1">my_tags &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_tags.html">get_tags</a></span>(my_con, <span class="dt">animal_project_code =</span> <span class="st">"phd_reubens"</span>)</a>
+<p>The transmitters/tags metadata can be accessed by the <code>get_tags</code> function:</p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb13-1" data-line-number="1">my_tags &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_tags.html">get_tags</a></span>(con)</a>
 <a class="sourceLine" id="cb13-2" data-line-number="2"><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(my_tags, <span class="dv">10</span>) <span class="co"># print 10 first</span></a>
 <a class="sourceLine" id="cb13-3" data-line-number="3"><span class="co">#&gt; # A tibble: 10 x 45</span></a>
 <a class="sourceLine" id="cb13-4" data-line-number="4"><span class="co">#&gt;       pk tag_id tag_id_alternat… telemetry_type manufacturer model frequency</span></a>
 <a class="sourceLine" id="cb13-5" data-line-number="5"><span class="co">#&gt;    &lt;int&gt; &lt;chr&gt;  &lt;chr&gt;            &lt;chr&gt;          &lt;chr&gt;        &lt;chr&gt; &lt;chr&gt;    </span></a>
-<a class="sourceLine" id="cb13-6" data-line-number="6"><span class="co">#&gt;  1    63 A69-1… &lt;NA&gt;             Acoustic       VEMCO        V9-1x 069k     </span></a>
-<a class="sourceLine" id="cb13-7" data-line-number="7"><span class="co">#&gt;  2    64 A69-1… &lt;NA&gt;             Acoustic       VEMCO        V9-1x 069k     </span></a>
-<a class="sourceLine" id="cb13-8" data-line-number="8"><span class="co">#&gt;  3    65 A69-1… &lt;NA&gt;             Acoustic       VEMCO        V9-1x 069k     </span></a>
-<a class="sourceLine" id="cb13-9" data-line-number="9"><span class="co">#&gt;  4    66 A69-1… &lt;NA&gt;             Acoustic       VEMCO        V9-1x 069k     </span></a>
-<a class="sourceLine" id="cb13-10" data-line-number="10"><span class="co">#&gt;  5    84 A69-1… &lt;NA&gt;             Acoustic       VEMCO        V13-… 069k     </span></a>
-<a class="sourceLine" id="cb13-11" data-line-number="11"><span class="co">#&gt;  6    86 A69-1… &lt;NA&gt;             Acoustic       VEMCO        V13-… 069k     </span></a>
-<a class="sourceLine" id="cb13-12" data-line-number="12"><span class="co">#&gt;  7    87 A69-1… &lt;NA&gt;             Acoustic       VEMCO        V13-… 069k     </span></a>
-<a class="sourceLine" id="cb13-13" data-line-number="13"><span class="co">#&gt;  8    85 A69-1… &lt;NA&gt;             Acoustic       VEMCO        V13-… 069k     </span></a>
-<a class="sourceLine" id="cb13-14" data-line-number="14"><span class="co">#&gt;  9    88 A69-1… &lt;NA&gt;             Acoustic       VEMCO        V13-… 069k     </span></a>
-<a class="sourceLine" id="cb13-15" data-line-number="15"><span class="co">#&gt; 10    89 A69-1… &lt;NA&gt;             Acoustic       VEMCO        V13-… 069k     </span></a>
+<a class="sourceLine" id="cb13-6" data-line-number="6"><span class="co">#&gt;  1  1883 A69-9… &lt;NA&gt;             acoustic       VEMCO        V13A… 069k     </span></a>
+<a class="sourceLine" id="cb13-7" data-line-number="7"><span class="co">#&gt;  2  3582 S256-… A69-1105-57      Acoustic       THELMA       T-MP… &lt;NA&gt;     </span></a>
+<a class="sourceLine" id="cb13-8" data-line-number="8"><span class="co">#&gt;  3  2391 R64K-… A69-1303-1242    acoustic tag   THELMA       LP-7… 69kHz    </span></a>
+<a class="sourceLine" id="cb13-9" data-line-number="9"><span class="co">#&gt;  4  2435 R64K-… A69-1303-2372    acoustic tag   THELMA       ID-L… 69kHz    </span></a>
+<a class="sourceLine" id="cb13-10" data-line-number="10"><span class="co">#&gt;  5  1802 A69-9… &lt;NA&gt;             acoustic       VEMCO        V13A… 069k     </span></a>
+<a class="sourceLine" id="cb13-11" data-line-number="11"><span class="co">#&gt;  6  1447 A69-1… &lt;NA&gt;             acoustic       VEMCO        V13-… 069k     </span></a>
+<a class="sourceLine" id="cb13-12" data-line-number="12"><span class="co">#&gt;  7   284 A69-1… &lt;NA&gt;             Acoustic       VEMCO        V13-… 069k     </span></a>
+<a class="sourceLine" id="cb13-13" data-line-number="13"><span class="co">#&gt;  8  3074 A69-9… &lt;NA&gt;             acoustic       VEMCO        V13A… 069k     </span></a>
+<a class="sourceLine" id="cb13-14" data-line-number="14"><span class="co">#&gt;  9  3248 A69-1… &lt;NA&gt;             acoustic       VEMCO        V13   &lt;NA&gt;     </span></a>
+<a class="sourceLine" id="cb13-15" data-line-number="15"><span class="co">#&gt; 10  3497 S256-… A69-1105-99      acoustic       THELMA       ADT-… &lt;NA&gt;     </span></a>
 <a class="sourceLine" id="cb13-16" data-line-number="16"><span class="co">#&gt; # … with 38 more variables: type &lt;chr&gt;, serial_number &lt;chr&gt;,</span></a>
 <a class="sourceLine" id="cb13-17" data-line-number="17"><span class="co">#&gt; #   tag_id_protocol &lt;chr&gt;, tag_id_code &lt;chr&gt;, status &lt;chr&gt;,</span></a>
 <a class="sourceLine" id="cb13-18" data-line-number="18"><span class="co">#&gt; #   activation_date &lt;dttm&gt;, battery_estimated_life &lt;chr&gt;,</span></a>
@@ -347,9 +384,8 @@
 <div id="detections-data" class="section level2">
 <h2 class="hasAnchor">
 <a href="#detections-data" class="anchor"></a>Detections data</h2>
-<p>The raw detections are the core for any type of analysis and access is provided by the <code>get_detections</code> function. Different filters are available which you can explore by typing <code><a href="../reference/get_detections.html">?get_detections</a></code> in the console.</p>
-<p>To narrow down the data request, filters are provided on animal/network project name, the deployment station name and the transmitter identifier to narrow. Furthermore, as these data sets can be large, some additional time-based filters are provided with a <code>start_date</code> and an <code>end_date</code>:</p>
-<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb14-1" data-line-number="1">my_detections &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_detections.html">get_detections</a></span>(my_con, <span class="dt">animal_project_code =</span> <span class="st">"phd_reubens"</span>, </a>
+<p>The raw detections are the core for any type of analysis and access is provided by the <code>get_detections</code> function. Different filters are available which you can explore by typing <code><a href="../reference/get_detections.html">?get_detections</a></code> in the console. To narrow down the data request, filters are provided on animal/network project name, the deployment station name and the transmitter identifier to narrow. Furthermore, as these data sets can be large, some additional time-based filters are provided with a <code>start_date</code> and an <code>end_date</code>:</p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb14-1" data-line-number="1">my_detections &lt;-<span class="st"> </span><span class="kw"><a href="../reference/get_detections.html">get_detections</a></span>(con, <span class="dt">animal_project_code =</span> <span class="st">"phd_reubens"</span>, </a>
 <a class="sourceLine" id="cb14-2" data-line-number="2">                                <span class="dt">start_date =</span> <span class="st">"2011-01-28"</span>, <span class="dt">end_date =</span> <span class="st">"2011-02-01"</span>)</a>
 <a class="sourceLine" id="cb14-3" data-line-number="3"><span class="kw"><a href="https://rdrr.io/r/utils/head.html">head</a></span>(my_detections, <span class="dv">10</span>) <span class="co"># print 10 first</span></a>
 <a class="sourceLine" id="cb14-4" data-line-number="4"><span class="co">#&gt; # A tibble: 10 x 23</span></a>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 

--- a/docs/reference/check_date_time.html
+++ b/docs/reference/check_date_time.html
@@ -78,7 +78,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 

--- a/docs/reference/connect_to_etn.html
+++ b/docs/reference/connect_to_etn.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -144,12 +144,17 @@
 
     <p>con ODBC connection to ETN database.</p>
 
+    <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
+    <pre class="examples"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
+<span class='no'>con</span> <span class='kw'>&lt;-</span> <span class='fu'>connect_to_etn</span>(<span class='fu'><a href='https://rdrr.io/r/base/Sys.getenv.html'>Sys.getenv</a></span>(<span class='st'>"userid"</span>), <span class='fu'><a href='https://rdrr.io/r/base/Sys.getenv.html'>Sys.getenv</a></span>(<span class='st'>"pwd"</span>))
+}</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>
     <ul class="nav nav-pills nav-stacked">
       <li><a href="#arguments">Arguments</a></li>
       <li><a href="#value">Value</a></li>
+      <li><a href="#examples">Examples</a></li>
     </ul>
 
   </div>

--- a/docs/reference/etn-deprecated.html
+++ b/docs/reference/etn-deprecated.html
@@ -78,7 +78,7 @@ the near future." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 

--- a/docs/reference/get_animals.html
+++ b/docs/reference/get_animals.html
@@ -78,7 +78,7 @@ scientific name." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -127,7 +127,11 @@ scientific name." />
 scientific name.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>get_animals</span>(<span class='no'>connection</span>, <span class='kw'>animal_project_code</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>scientific_name</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)</pre>
+    <pre class="usage"><span class='fu'>get_animals</span>(
+  <span class='kw'>connection</span> <span class='kw'>=</span> <span class='no'>con</span>,
+  <span class='kw'>animal_project_code</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='kw'>scientific_name</span> <span class='kw'>=</span> <span class='kw'>NULL</span>
+)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">

--- a/docs/reference/get_deployments.html
+++ b/docs/reference/get_deployments.html
@@ -78,7 +78,7 @@ receiver status and/or open deployments." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -128,7 +128,7 @@ receiver status and/or open deployments.</p>
     </div>
 
     <pre class="usage"><span class='fu'>get_deployments</span>(
-  <span class='no'>connection</span>,
+  <span class='kw'>connection</span> <span class='kw'>=</span> <span class='no'>con</span>,
   <span class='kw'>network_project_code</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>receiver_status</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>open_only</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>
@@ -151,8 +151,8 @@ receiver status and/or open deployments.</p>
     </tr>
     <tr>
       <th>open_only</th>
-      <td><p>(logical) Restrict to deployments that are currently open (i.e. no end date defined).  Default:
-<code>TRUE</code>.</p></td>
+      <td><p>(logical) Restrict to deployments that are currently open
+(i.e. no end date defined). Default: <code>TRUE</code>.</p></td>
     </tr>
     </table>
 
@@ -171,13 +171,13 @@ receiver status and/or open deployments.</p>
 <span class='fu'>get_deployments</span>(<span class='no'>con</span>, <span class='kw'>open_only</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>)
 
 <span class='co'># Get open deployments from specific network project(s)</span>
-<span class='fu'>get_deployments</span>(<span class='no'>con</span>, <span class='kw'>network_project_code</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"thornton"</span>, <span class='st'>"leopold"</span>))
+<span class='fu'>get_deployments</span>(<span class='no'>con</span>, <span class='kw'>network_project_code</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"ws1"</span>, <span class='st'>"ws2"</span>))
 
 <span class='co'># Get open deployments with a specific receiver status</span>
 <span class='fu'>get_deployments</span>(<span class='no'>con</span>, <span class='kw'>receiver_status</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"Broken"</span>, <span class='st'>"Lost"</span>))
 
 <span class='co'># Get open deployments from a specific project from active receivers</span>
-<span class='fu'>get_deployments</span>(<span class='no'>con</span>, <span class='kw'>network_project_code</span> <span class='kw'>=</span> <span class='st'>"thornton"</span>, <span class='kw'>receiver_status</span> <span class='kw'>=</span> <span class='st'>"Active"</span>)
+<span class='fu'>get_deployments</span>(<span class='no'>con</span>, <span class='kw'>network_project_code</span> <span class='kw'>=</span> <span class='st'>"ws1"</span>, <span class='kw'>receiver_status</span> <span class='kw'>=</span> <span class='st'>"Active"</span>)
 }</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">

--- a/docs/reference/get_detections.html
+++ b/docs/reference/get_detections.html
@@ -79,7 +79,7 @@ Use limit to limit the number of returned records" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -130,7 +130,7 @@ Use <code>limit</code> to limit the number of returned records</p>
     </div>
 
     <pre class="usage"><span class='fu'>get_detections</span>(
-  <span class='no'>connection</span>,
+  <span class='kw'>connection</span> <span class='kw'>=</span> <span class='no'>con</span>,
   <span class='kw'>network_project_code</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>animal_project_code</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>start_date</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
@@ -139,7 +139,7 @@ Use <code>limit</code> to limit the number of returned records</p>
   <span class='kw'>tag_id</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>receiver_id</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>scientific_name</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>limit</span> <span class='kw'>=</span> <span class='kw'>NULL</span>
+  <span class='kw'>limit</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>
 )</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
@@ -187,8 +187,8 @@ well.</p></td>
     </tr>
     <tr>
       <th>limit</th>
-      <td><p>(integer) The number of records to return (useful for testing
-purposes).</p></td>
+      <td><p>(logical) Limit the number of returned records to 100 (useful for testing
+purposes). Default: <code>TRUE</code>.</p></td>
     </tr>
     </table>
 
@@ -200,36 +200,49 @@ purposes).</p></td>
     <pre class="examples"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
 <span class='no'>con</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='connect_to_etn.html'>connect_to_etn</a></span>(<span class='no'>your_username</span>, <span class='no'>your_password</span>)
 
-<span class='co'># Get detections filtered by start year and limited to 100 records</span>
-<span class='fu'>get_detections</span>(<span class='no'>con</span>, <span class='kw'>start_date</span> <span class='kw'>=</span> <span class='st'>"2017"</span>, <span class='kw'>limit</span> <span class='kw'>=</span> <span class='fl'>100</span>)
+<span class='co'># Get detections filtered by start year, limited to 100 records by default</span>
+<span class='fu'>get_detections</span>(<span class='no'>con</span>, <span class='kw'>start_date</span> <span class='kw'>=</span> <span class='st'>"2017"</span>)
 
 <span class='co'># Get detections within a time frame for a specific animal project and</span>
 <span class='co'># network project</span>
-<span class='fu'>get_detections</span>(<span class='no'>con</span>,
+<span class='fu'>get_detections</span>(
+  <span class='no'>con</span>,
   <span class='kw'>animal_project_code</span> <span class='kw'>=</span> <span class='st'>"phd_reubens"</span>,
   <span class='kw'>network_project_code</span> <span class='kw'>=</span> <span class='st'>"thornton"</span>, <span class='kw'>start_date</span> <span class='kw'>=</span> <span class='st'>"2011-01-28"</span>,
-  <span class='kw'>end_date</span> <span class='kw'>=</span> <span class='st'>"2011-02-01"</span>
+  <span class='kw'>end_date</span> <span class='kw'>=</span> <span class='st'>"2011-02-01"</span>,
+  <span class='kw'>limit</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>
 )
 
 <span class='co'># Get detections for a specific animal project at specific stations</span>
-<span class='fu'>get_detections</span>(<span class='no'>con</span>,
+<span class='fu'>get_detections</span>(
+  <span class='no'>con</span>,
   <span class='kw'>animal_project_code</span> <span class='kw'>=</span> <span class='st'>"phd_reubens"</span>,
-  <span class='kw'>station_name</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"R03"</span>, <span class='st'>"R05"</span>)
+  <span class='kw'>station_name</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"R03"</span>, <span class='st'>"R05"</span>),
+  <span class='kw'>limit</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>
 )
 
-<span class='co'># Get detectios for a specific tag</span>
-<span class='fu'>get_detections</span>(<span class='no'>con</span>, <span class='kw'>tag_id</span> <span class='kw'>=</span> <span class='st'>"A69-1303-65302"</span>)
+<span class='co'># Get detections for a specific tag</span>
+<span class='fu'>get_detections</span>(
+  <span class='no'>con</span>,
+  <span class='kw'>tag_id</span> <span class='kw'>=</span> <span class='st'>"A69-1303-65302"</span>,
+  <span class='kw'>limit</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>
+)
 
 <span class='co'># Get detections for a specific receiver during a specific time period</span>
-<span class='fu'>get_detections</span>(<span class='no'>con</span>,
-  <span class='kw'>receiver_id</span> <span class='kw'>=</span> <span class='st'>"VR2W-122360"</span>, <span class='kw'>start_date</span> <span class='kw'>=</span> <span class='st'>"2015-12-03"</span>,
-  <span class='kw'>end_date</span> <span class='kw'>=</span> <span class='st'>"2015-12-05"</span>
+<span class='fu'>get_detections</span>(
+  <span class='no'>con</span>,
+  <span class='kw'>receiver_id</span> <span class='kw'>=</span> <span class='st'>"VR2W-122360"</span>,
+  <span class='kw'>start_date</span> <span class='kw'>=</span> <span class='st'>"2015-12-03"</span>,
+  <span class='kw'>end_date</span> <span class='kw'>=</span> <span class='st'>"2015-12-05"</span>,
+  <span class='kw'>limit</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>
 )
 <span class='co'># Get detections for a specific species during a given period</span>
-<span class='fu'>get_detections</span>(<span class='no'>con</span>,
+<span class='fu'>get_detections</span>(
+  <span class='no'>con</span>,
   <span class='kw'>scientific_name</span> <span class='kw'>=</span> <span class='st'>"Anguilla anguilla"</span>,
   <span class='kw'>start_date</span> <span class='kw'>=</span> <span class='st'>"2015-12-03"</span>,
-  <span class='kw'>end_date</span> <span class='kw'>=</span> <span class='st'>"2015-12-05"</span>
+  <span class='kw'>end_date</span> <span class='kw'>=</span> <span class='st'>"2015-12-05"</span>,
+  <span class='kw'>limit</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>
 )
 }</div></pre>
   </div>

--- a/docs/reference/get_projects.html
+++ b/docs/reference/get_projects.html
@@ -78,7 +78,7 @@ projects." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -127,7 +127,7 @@ projects." />
 projects.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>get_projects</span>(<span class='no'>connection</span>, <span class='kw'>project_type</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)</pre>
+    <pre class="usage"><span class='fu'>get_projects</span>(<span class='kw'>connection</span> <span class='kw'>=</span> <span class='no'>con</span>, <span class='kw'>project_type</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">

--- a/docs/reference/get_receivers.html
+++ b/docs/reference/get_receivers.html
@@ -43,7 +43,7 @@
 
 
 <meta property="og:title" content="Get receiver metadata — get_receivers" />
-<meta property="og:description" content="Get metadata for receivers, with option to filter on network project." />
+<meta property="og:description" content="Get metadata for receivers, with option to filter on receiver id." />
 <meta property="og:image" content="https://inbo.github.io/etn/logo.png" />
 <meta name="twitter:card" content="summary" />
 
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -122,10 +122,10 @@
     </div>
 
     <div class="ref-description">
-    <p>Get metadata for receivers, with option to filter on network project.</p>
+    <p>Get metadata for receivers, with option to filter on receiver id.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>get_receivers</span>(<span class='no'>connection</span>, <span class='kw'>network_project_code</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)</pre>
+    <pre class="usage"><span class='fu'>get_receivers</span>(<span class='kw'>connection</span> <span class='kw'>=</span> <span class='no'>con</span>, <span class='kw'>receiver_id</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -135,8 +135,8 @@
       <td><p>A valid connection to the ETN database.</p></td>
     </tr>
     <tr>
-      <th>network_project_code</th>
-      <td><p>(string) One or more network projects.</p></td>
+      <th>receiver_id</th>
+      <td><p>(string) One or more receiver ids.</p></td>
     </tr>
     </table>
 
@@ -151,9 +151,9 @@
 <span class='co'># Get all receivers</span>
 <span class='fu'>get_receivers</span>(<span class='no'>con</span>)
 
-<span class='co'># Get receivers linked to specific network project(s)</span>
-<span class='fu'>get_receivers</span>(<span class='no'>con</span>, <span class='kw'>network_project_code</span> <span class='kw'>=</span> <span class='st'>"thornton"</span>)
-<span class='fu'>get_receivers</span>(<span class='no'>con</span>, <span class='kw'>network_project_code</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"thornton"</span>, <span class='st'>"2012_leopoldkanaal"</span>))
+<span class='co'># Get specific receivers</span>
+<span class='fu'>get_receivers</span>(<span class='no'>con</span>, <span class='kw'>receiver_id</span> <span class='kw'>=</span> <span class='st'>"VR2-4842c"</span>)
+<span class='fu'>get_receivers</span>(<span class='no'>con</span>, <span class='kw'>receiver_id</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"VR2AR-545719"</span>, <span class='st'>"VR2AR-545720"</span>))
 }</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">

--- a/docs/reference/get_tags.html
+++ b/docs/reference/get_tags.html
@@ -43,8 +43,8 @@
 
 
 <meta property="og:title" content="Get tag metadata — get_tags" />
-<meta property="og:description" content="Get metadata for tags. Only returns tags that can be linked to an animal (and
-thus an animal project). By default, reference tags are excluded." />
+<meta property="og:description" content="Get metadata for tags, with option to filter on tag id. By default, reference
+tags are excluded." />
 <meta property="og:image" content="https://inbo.github.io/etn/logo.png" />
 <meta name="twitter:card" content="summary" />
 
@@ -78,7 +78,7 @@ thus an animal project). By default, reference tags are excluded." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -123,15 +123,11 @@ thus an animal project). By default, reference tags are excluded." />
     </div>
 
     <div class="ref-description">
-    <p>Get metadata for tags. Only returns tags that can be linked to an animal (and
-thus an animal project). By default, reference tags are excluded.</p>
+    <p>Get metadata for tags, with option to filter on tag id. By default, reference
+tags are excluded.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>get_tags</span>(
-  <span class='no'>connection</span>,
-  <span class='kw'>animal_project_code</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>include_reference_tags</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>
-)</pre>
+    <pre class="usage"><span class='fu'>get_tags</span>(<span class='kw'>connection</span> <span class='kw'>=</span> <span class='no'>con</span>, <span class='kw'>tag_id</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>include_ref_tags</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -141,11 +137,11 @@ thus an animal project). By default, reference tags are excluded.</p>
       <td><p>A valid connection with the ETN database.</p></td>
     </tr>
     <tr>
-      <th>animal_project_code</th>
-      <td><p>(string) One or more animal projects.</p></td>
+      <th>tag_id</th>
+      <td><p>(string) One or more tag ids.</p></td>
     </tr>
     <tr>
-      <th>include_reference_tags</th>
+      <th>include_ref_tags</th>
       <td><p>(logical) Include reference tags. Default:
 <code>FALSE</code>.</p></td>
     </tr>
@@ -163,11 +159,11 @@ thus an animal project). By default, reference tags are excluded.</p>
 <span class='fu'>get_tags</span>(<span class='no'>con</span>)
 
 <span class='co'># Get all tags, including reference tags</span>
-<span class='fu'>get_tags</span>(<span class='no'>con</span>, <span class='kw'>include_reference_tags</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
+<span class='fu'>get_tags</span>(<span class='no'>con</span>, <span class='kw'>include_ref_tags</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
 
-<span class='co'># Get tags linked to specific animal project(s)</span>
-<span class='fu'>get_tags</span>(<span class='no'>con</span>, <span class='kw'>animal_project_code</span> <span class='kw'>=</span> <span class='st'>"phd_reubens"</span>)
-<span class='fu'>get_tags</span>(<span class='no'>con</span>, <span class='kw'>animal_project_code</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"phd_reubens"</span>, <span class='st'>"2012_leopoldkanaal"</span>))
+<span class='co'># Get specific tags (will automatically set include_ref_tags = TRUE)</span>
+<span class='fu'>get_tags</span>(<span class='no'>con</span>, <span class='kw'>tag_id</span> <span class='kw'>=</span> <span class='st'>"A69-1303-65313"</span>)
+<span class='fu'>get_tags</span>(<span class='no'>con</span>, <span class='kw'>tag_id</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"A69-1601-1705"</span>, <span class='st'>"A69-1601-1707"</span>))
 }</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -76,7 +76,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 

--- a/docs/reference/list_animal_project_codes.html
+++ b/docs/reference/list_animal_project_codes.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -125,7 +125,7 @@
     <p>List all available animal project codes</p>
     </div>
 
-    <pre class="usage"><span class='fu'>list_animal_project_codes</span>(<span class='no'>connection</span>)</pre>
+    <pre class="usage"><span class='fu'>list_animal_project_codes</span>(<span class='kw'>connection</span> <span class='kw'>=</span> <span class='no'>con</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -138,7 +138,7 @@
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
-    <p>A vector of all unique <code>project_code</code> of <code>type="animal"</code> present in <code>projects</code>.</p>
+    <p>A vector of all unique <code>project_code</code> of <code>project_type="animal"</code> present in <code>projects</code>.</p>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">

--- a/docs/reference/list_network_project_codes.html
+++ b/docs/reference/list_network_project_codes.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -125,7 +125,7 @@
     <p>List all available network project codes</p>
     </div>
 
-    <pre class="usage"><span class='fu'>list_network_project_codes</span>(<span class='no'>connection</span>)</pre>
+    <pre class="usage"><span class='fu'>list_network_project_codes</span>(<span class='kw'>connection</span> <span class='kw'>=</span> <span class='no'>con</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -138,7 +138,7 @@
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
-    <p>A vector of all unique <code>project_code</code> of <code>type="network"</code> present in <code>projects</code>.</p>
+    <p>A vector of all unique <code>project_code</code> of <code>project_type="network"</code> present in <code>projects</code>.</p>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">

--- a/docs/reference/list_receiver_ids.html
+++ b/docs/reference/list_receiver_ids.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -125,7 +125,7 @@
     <p>List all available network receiver ids</p>
     </div>
 
-    <pre class="usage"><span class='fu'>list_receiver_ids</span>(<span class='no'>connection</span>)</pre>
+    <pre class="usage"><span class='fu'>list_receiver_ids</span>(<span class='kw'>connection</span> <span class='kw'>=</span> <span class='no'>con</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">

--- a/docs/reference/list_scientific_names.html
+++ b/docs/reference/list_scientific_names.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -125,7 +125,7 @@
     <p>List all available scientific names</p>
     </div>
 
-    <pre class="usage"><span class='fu'>list_scientific_names</span>(<span class='no'>connection</span>)</pre>
+    <pre class="usage"><span class='fu'>list_scientific_names</span>(<span class='kw'>connection</span> <span class='kw'>=</span> <span class='no'>con</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">

--- a/docs/reference/list_station_names.html
+++ b/docs/reference/list_station_names.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -125,7 +125,7 @@
     <p>List all available station names</p>
     </div>
 
-    <pre class="usage"><span class='fu'>list_station_names</span>(<span class='no'>connection</span>)</pre>
+    <pre class="usage"><span class='fu'>list_station_names</span>(<span class='kw'>connection</span> <span class='kw'>=</span> <span class='no'>con</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">

--- a/docs/reference/list_tag_ids.html
+++ b/docs/reference/list_tag_ids.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">etn</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9093</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.1.0.9101</span>
       </span>
     </div>
 
@@ -125,7 +125,7 @@
     <p>List all available tag ids</p>
     </div>
 
-    <pre class="usage"><span class='fu'>list_tag_ids</span>(<span class='no'>connection</span>)</pre>
+    <pre class="usage"><span class='fu'>list_tag_ids</span>(<span class='kw'>connection</span> <span class='kw'>=</span> <span class='no'>con</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -4,16 +4,7 @@
     <loc>https://inbo.github.io/etn/index.html</loc>
   </url>
   <url>
-    <loc>https://inbo.github.io/etn/reference/check_connection.html</loc>
-  </url>
-  <url>
     <loc>https://inbo.github.io/etn/reference/check_date_time.html</loc>
-  </url>
-  <url>
-    <loc>https://inbo.github.io/etn/reference/check_value.html</loc>
-  </url>
-  <url>
-    <loc>https://inbo.github.io/etn/reference/collapse_transformer.html</loc>
   </url>
   <url>
     <loc>https://inbo.github.io/etn/reference/connect_to_etn.html</loc>

--- a/man/connect_to_etn.Rd
+++ b/man/connect_to_etn.Rd
@@ -17,3 +17,8 @@ con ODBC connection to ETN database.
 \description{
 Connect to the database using username and password.
 }
+\examples{
+\dontrun{
+con <- connect_to_etn(Sys.getenv("userid"), Sys.getenv("pwd")))
+}
+}

--- a/man/connect_to_etn.Rd
+++ b/man/connect_to_etn.Rd
@@ -19,6 +19,6 @@ Connect to the database using username and password.
 }
 \examples{
 \dontrun{
-con <- connect_to_etn(Sys.getenv("userid"), Sys.getenv("pwd")))
+con <- connect_to_etn(Sys.getenv("userid"), Sys.getenv("pwd"))
 }
 }

--- a/man/get_animals.Rd
+++ b/man/get_animals.Rd
@@ -4,7 +4,11 @@
 \alias{get_animals}
 \title{Get animal metadata}
 \usage{
-get_animals(connection, animal_project_code = NULL, scientific_name = NULL)
+get_animals(
+  connection = con,
+  animal_project_code = NULL,
+  scientific_name = NULL
+)
 }
 \arguments{
 \item{connection}{A valid connection to the ETN database.}

--- a/man/get_deployments.Rd
+++ b/man/get_deployments.Rd
@@ -39,12 +39,12 @@ get_deployments(con)
 get_deployments(con, open_only = FALSE)
 
 # Get open deployments from specific network project(s)
-get_deployments(con, network_project_code = c("thornton", "leopold"))
+get_deployments(con, network_project_code = c("ws1", "ws2"))
 
 # Get open deployments with a specific receiver status
 get_deployments(con, receiver_status = c("Broken", "Lost"))
 
 # Get open deployments from a specific project from active receivers
-get_deployments(con, network_project_code = "thornton", receiver_status = "Active")
+get_deployments(con, network_project_code = "ws1", receiver_status = "Active")
 }
 }

--- a/man/get_deployments.Rd
+++ b/man/get_deployments.Rd
@@ -5,7 +5,7 @@
 \title{Get deployment metadata}
 \usage{
 get_deployments(
-  connection,
+  connection = con,
   network_project_code = NULL,
   receiver_status = NULL,
   open_only = TRUE
@@ -18,8 +18,8 @@ get_deployments(
 
 \item{receiver_status}{(string) One or more receiver status.}
 
-\item{open_only}{(logical) Restrict to deployments that are currently open (i.e. no end date defined).  Default:
-\code{TRUE}.}
+\item{open_only}{(logical) Restrict to deployments that are currently open
+(i.e. no end date defined). Default: \code{TRUE}.}
 }
 \value{
 A tibble (tidyverse data.frame).

--- a/man/get_detections.Rd
+++ b/man/get_detections.Rd
@@ -80,7 +80,8 @@ get_detections(
 get_detections(
   con,
   tag_id = "A69-1303-65302",
-  limit = FALSE)
+  limit = FALSE
+)
 
 # Get detections for a specific receiver during a specific time period
 get_detections(

--- a/man/get_detections.Rd
+++ b/man/get_detections.Rd
@@ -5,7 +5,7 @@
 \title{Get detections data}
 \usage{
 get_detections(
-  connection,
+  connection = con,
   network_project_code = NULL,
   animal_project_code = NULL,
   start_date = NULL,
@@ -14,7 +14,7 @@ get_detections(
   tag_id = NULL,
   receiver_id = NULL,
   scientific_name = NULL,
-  limit = NULL
+  limit = TRUE
 )
 }
 \arguments{
@@ -40,8 +40,8 @@ well.}
 
 \item{scientific_name}{(character) One or more scientific names.}
 
-\item{limit}{(integer) The number of records to return (useful for testing
-purposes).}
+\item{limit}{(logical) Limit the number of returned records to 100 (useful for testing
+purposes). Default: \code{TRUE}.}
 }
 \value{
 A tibble (tidyverse data.frame).
@@ -55,36 +55,48 @@ Use \code{limit} to limit the number of returned records
 \dontrun{
 con <- connect_to_etn(your_username, your_password)
 
-# Get detections filtered by start year and limited to 100 records
-get_detections(con, start_date = "2017", limit = 100)
+# Get detections filtered by start year, limited to 100 records by default
+get_detections(con, start_date = "2017")
 
 # Get detections within a time frame for a specific animal project and
 # network project
-get_detections(con,
+get_detections(
+  con,
   animal_project_code = "phd_reubens",
   network_project_code = "thornton", start_date = "2011-01-28",
-  end_date = "2011-02-01"
+  end_date = "2011-02-01",
+  limit = FALSE
 )
 
 # Get detections for a specific animal project at specific stations
-get_detections(con,
+get_detections(
+  con,
   animal_project_code = "phd_reubens",
-  station_name = c("R03", "R05")
+  station_name = c("R03", "R05"),
+  limit = FALSE
 )
 
 # Get detections for a specific tag
-get_detections(con, tag_id = "A69-1303-65302")
+get_detections(
+  con,
+  tag_id = "A69-1303-65302",
+  limit = FALSE)
 
 # Get detections for a specific receiver during a specific time period
-get_detections(con,
-  receiver_id = "VR2W-122360", start_date = "2015-12-03",
-  end_date = "2015-12-05"
+get_detections(
+  con,
+  receiver_id = "VR2W-122360",
+  start_date = "2015-12-03",
+  end_date = "2015-12-05",
+  limit = FALSE
 )
 # Get detections for a specific species during a given period
-get_detections(con,
+get_detections(
+  con,
   scientific_name = "Anguilla anguilla",
   start_date = "2015-12-03",
-  end_date = "2015-12-05"
+  end_date = "2015-12-05",
+  limit = FALSE
 )
 }
 }

--- a/man/get_projects.Rd
+++ b/man/get_projects.Rd
@@ -4,7 +4,7 @@
 \alias{get_projects}
 \title{Get project metadata}
 \usage{
-get_projects(connection, project_type = NULL)
+get_projects(connection = con, project_type = NULL)
 }
 \arguments{
 \item{connection}{A valid connection to the ETN database.}

--- a/man/get_receivers.Rd
+++ b/man/get_receivers.Rd
@@ -4,7 +4,7 @@
 \alias{get_receivers}
 \title{Get receiver metadata}
 \usage{
-get_receivers(connection = con)
+get_receivers(connection = con, receiver_id = NULL)
 }
 \arguments{
 \item{connection}{A valid connection to the ETN database.}
@@ -15,7 +15,7 @@ get_receivers(connection = con)
 A tibble (tidyverse data.frame).
 }
 \description{
-Get metadata for receivers.
+Get metadata for receivers, with option to filter on receiver id.
 }
 \examples{
 \dontrun{
@@ -23,5 +23,9 @@ con <- connect_to_etn(your_username, your_password)
 
 # Get all receivers
 get_receivers(con)
+
+# Get specific receivers
+get_receivers(con, receiver_id = "VR2-4842c")
+get_receivers(con, receiver_id = c("VR2AR-545719", "VR2AR-545720"))
 }
 }

--- a/man/get_receivers.Rd
+++ b/man/get_receivers.Rd
@@ -4,10 +4,12 @@
 \alias{get_receivers}
 \title{Get receiver metadata}
 \usage{
-get_receivers(connection)
+get_receivers(connection = con)
 }
 \arguments{
 \item{connection}{A valid connection to the ETN database.}
+
+\item{receiver_id}{(string) One or more receiver ids.}
 }
 \value{
 A tibble (tidyverse data.frame).

--- a/man/get_tags.Rd
+++ b/man/get_tags.Rd
@@ -4,26 +4,22 @@
 \alias{get_tags}
 \title{Get tag metadata}
 \usage{
-get_tags(
-  connection = con,
-  animal_project_code = NULL,
-  include_reference_tags = FALSE
-)
+get_tags(connection = con, tag_id = NULL, include_ref_tags = FALSE)
 }
 \arguments{
 \item{connection}{A valid connection with the ETN database.}
 
-\item{animal_project_code}{(string) One or more animal projects.}
+\item{tag_id}{(string) One or more tag ids.}
 
-\item{include_reference_tags}{(logical) Include reference tags. Default:
+\item{include_ref_tags}{(logical) Include reference tags. Default:
 \code{FALSE}.}
 }
 \value{
 A tibble (tidyverse data.frame).
 }
 \description{
-Get metadata for tags. Only returns tags that can be linked to an animal (and
-thus an animal project). By default, reference tags are excluded.
+Get metadata for tags, with option to filter on tag_id. By default, reference
+tags are excluded.
 }
 \examples{
 \dontrun{
@@ -33,10 +29,10 @@ con <- connect_to_etn(your_username, your_password)
 get_tags(con)
 
 # Get all tags, including reference tags
-get_tags(con, include_reference_tags = TRUE)
+get_tags(con, include_ref_tags = TRUE)
 
-# Get tags linked to specific animal project(s)
-get_tags(con, animal_project_code = "phd_reubens")
-get_tags(con, animal_project_code = c("phd_reubens", "2012_leopoldkanaal"))
+# Get specific tags (will automatically set include_ref_tags = TRUE)
+get_tags(con, tag_id = "A69-1303-65313")
+get_tags(con, tag_id = c("A69-1601-1705", "A69-1601-1707"))
 }
 }

--- a/man/get_tags.Rd
+++ b/man/get_tags.Rd
@@ -5,7 +5,7 @@
 \title{Get tag metadata}
 \usage{
 get_tags(
-  connection,
+  connection = con,
   animal_project_code = NULL,
   include_reference_tags = FALSE
 )

--- a/man/get_tags.Rd
+++ b/man/get_tags.Rd
@@ -18,7 +18,7 @@ get_tags(connection = con, tag_id = NULL, include_ref_tags = FALSE)
 A tibble (tidyverse data.frame).
 }
 \description{
-Get metadata for tags, with option to filter on tag_id. By default, reference
+Get metadata for tags, with option to filter on tag id. By default, reference
 tags are excluded.
 }
 \examples{

--- a/man/list_animal_project_codes.Rd
+++ b/man/list_animal_project_codes.Rd
@@ -4,7 +4,7 @@
 \alias{list_animal_project_codes}
 \title{List all available animal project codes}
 \usage{
-list_animal_project_codes(connection)
+list_animal_project_codes(connection = con)
 }
 \arguments{
 \item{connection}{A valid connection to the ETN database.}

--- a/man/list_network_project_codes.Rd
+++ b/man/list_network_project_codes.Rd
@@ -4,7 +4,7 @@
 \alias{list_network_project_codes}
 \title{List all available network project codes}
 \usage{
-list_network_project_codes(connection)
+list_network_project_codes(connection = con)
 }
 \arguments{
 \item{connection}{A valid connection to the ETN database.}

--- a/man/list_receiver_ids.Rd
+++ b/man/list_receiver_ids.Rd
@@ -4,7 +4,7 @@
 \alias{list_receiver_ids}
 \title{List all available network receiver ids}
 \usage{
-list_receiver_ids(connection)
+list_receiver_ids(connection = con)
 }
 \arguments{
 \item{connection}{A valid connection to the ETN database.}

--- a/man/list_scientific_names.Rd
+++ b/man/list_scientific_names.Rd
@@ -4,7 +4,7 @@
 \alias{list_scientific_names}
 \title{List all available scientific names}
 \usage{
-list_scientific_names(connection)
+list_scientific_names(connection = con)
 }
 \arguments{
 \item{connection}{A valid connection to the ETN database.}

--- a/man/list_station_names.Rd
+++ b/man/list_station_names.Rd
@@ -4,7 +4,7 @@
 \alias{list_station_names}
 \title{List all available station names}
 \usage{
-list_station_names(connection)
+list_station_names(connection = con)
 }
 \arguments{
 \item{connection}{A valid connection to the ETN database.}

--- a/man/list_tag_ids.Rd
+++ b/man/list_tag_ids.Rd
@@ -4,7 +4,7 @@
 \alias{list_tag_ids}
 \title{List all available tag ids}
 \usage{
-list_tag_ids(connection)
+list_tag_ids(connection = con)
 }
 \arguments{
 \item{connection}{A valid connection to the ETN database.}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,5 @@
 library(testthat)
+library(dplyr)
 library(etn)
 
 test_check("etn")

--- a/tests/testthat/test-check_date_time.R
+++ b/tests/testthat/test-check_date_time.R
@@ -1,4 +1,4 @@
-testthat::test_that("check_date_time", {
+testthat::test_that("Test input", {
   expect_true(check_date_time("1985-11-21") == "1985-11-21")
   expect_true(check_date_time("1985-11") == "1985-11-01")
   expect_true(check_date_time("1985") == "1985-01-01")
@@ -13,7 +13,7 @@ testthat::test_that("check_date_time", {
     check_date_time("01-03-1973"),
     paste(
       "The given start_date, 01-03-1973, is not in a valid date",
-      "format. Use a ymd format or shorter,",
+      "format. Use a yyyy-mm-dd format or shorter,",
       "e.g. 2012-11-21, 2012-11 or 2012."
     )
   )

--- a/tests/testthat/test-check_value.R
+++ b/tests/testthat/test-check_value.R
@@ -3,78 +3,50 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
-valid_network_projects <- list_network_project_codes(con)
 valid_animal_projects <- list_animal_project_codes(con)
 
-testthat::test_that("check_value with project_type", {
-  expect_error(check_value(
-    "ani",
-    c("animal", "network"), "project_type"
-  ),
-  paste0(
-    "Not valid input value(s) for project_type input argument.",
-    "\nValid inputs are: animal and network."
-  ),
-  fixed = TRUE
+testthat::test_that("Test input for project_type", {
+  expect_error(
+    check_value("not_a_project_type", c("animal", "network"), "project_type"),
+    paste0(
+      "Invalid value(s) for project_type argument.",
+      "\nValid inputs are: animal and network."
+    ),
+    fixed = TRUE
   )
-  expect_error(check_value(
-    c("animal", "netw"),
-    c("animal", "network"), "project_type"
-  ),
-  paste0(
-    "Not valid input value(s) for project_type input argument.",
-    "\nValid inputs are: animal and network."
-  ),
-  fixed = TRUE
+  expect_error(
+    check_value(c("animal", "not_a_project_type"), c("animal", "network"), "project_type"),
+    paste0(
+      "Invalid value(s) for project_type argument.",
+      "\nValid inputs are: animal and network."
+    ),
+    fixed = TRUE
   )
-  expect_true(check_value(
-    "animal",
-    c("animal", "network"), "project_type"
-  ))
-  expect_true(check_value(NULL, c("animal", "network"), "project_type"))
-  expect_true(check_value(
-    c("animal", "network"),
-    c("animal", "network"), "project_type"
-  ))
+  expect_true(
+    check_value("animal", c("animal", "network"), "project_type")
+  )
+  expect_true(
+    check_value(NULL, c("animal", "network"), "project_type")
+  )
+  expect_true(
+    check_value(c("animal", "network"), c("animal", "network"), "project_type")
+  )
 })
 
-testthat::test_that("check_value with network_type", {
-  expect_error(check_value(
-    "I am not a network project",
-    valid_network_projects,
-    "network_project"
-  ))
-  expect_true(check_value(
-    c("thornton", "leopold"),
-    valid_network_projects,
-    "network_project"
-  ))
-  expect_true(check_value(
-    NULL,
-    valid_network_projects,
-    "network_project"
-  ))
-})
-
-testthat::test_that("check_value with animal_type", {
-  expect_error(check_value(
-    "I am not an animal project",
-    valid_animal_projects,
-    "animal_project"
-  ))
-  expect_true(check_value(
-    c("2012_leopoldkanaal", "phd_reubens"),
-    valid_animal_projects,
-    "animal_project"
-  ))
-  expect_true(check_value(
-    "2011_rivierprik",
-    valid_animal_projects,
-    "animal_project"
-  ))
-  expect_true(check_value(
-    NULL,
-    valid_animal_projects,
-    "animal_project"
-  ))
+testthat::test_that("Test input for animal_project", {
+  expect_error(
+    check_value("not_an_animal_project", valid_animal_projects, "animal_project")
+  )
+  expect_true(
+    check_value("2011_rivierprik", valid_animal_projects, "animal_project")
+  )
+  expect_true(
+    check_value(c("2012_leopoldkanaal", "phd_reubens"), valid_animal_projects, "animal_project")
+  )
+  expect_error(
+    check_value(c("2012_leopoldkanaal", "not_an_animal_project"), valid_animal_projects, "animal_project")
+  )
+  expect_true(
+    check_value(NULL, valid_animal_projects, "animal_project")
+  )
 })

--- a/tests/testthat/test-connect_to_etn.R
+++ b/tests/testthat/test-connect_to_etn.R
@@ -3,8 +3,8 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
-testthat::test_that("check_connection", {
-  expect_error(check_connection("I am not a connection"))
+testthat::test_that("Test connection", {
+  expect_error(check_connection("not_a_connection"))
   expect_true(check_connection(con))
   expect_true(isClass(con, "PostgreSQL"))
 })

--- a/tests/testthat/test-get_animals.R
+++ b/tests/testthat/test-get_animals.R
@@ -77,53 +77,81 @@ name1 <- "Gadus morhua"
 names_multiple <- c("Gadus morhua", "Sentinel", "Anguilla anguilla")
 
 animals_all <- get_animals(con)
-animals_project1 <- get_animals(con, animal_project_code = project1)
-animals_project2 <- get_animals(con, animal_project_code = project2)
-animals_projects_multiple <- get_animals(con, animal_project_code = projects_multiple)
-animals_names_multiple <- get_animals(con, scientific_name = names_multiple)
-animals_project1_name1 <- get_animals(con,
+animals_project1 <- get_animals(
+  con,
+  animal_project_code = project1
+)
+animals_project2 <- get_animals(
+  con,
+  animal_project_code = project2
+)
+animals_projects_multiple <- get_animals(
+  con,
+  animal_project_code = projects_multiple
+)
+animals_names_multiple <- get_animals(
+  con,
+  scientific_name = names_multiple
+)
+animals_project1_name1 <- get_animals(
+  con,
   animal_project_code = project1,
   scientific_name = name1
 )
 
 testthat::test_that("test_input_get_animals", {
-  expect_error(
-    get_animals("I am not a connection"),
+  expect_error(get_animals("I am not a connection"),
     "Not a connection object to database."
   )
+  expect_error(get_animals(
+    con,
+    network_project_code = "very_bad_project"
+  ))
+  expect_error(get_animals(
+    con,
+    network_project_code = c("thornton", "very_bad_project")
+  ))
 })
 
 
 testthat::test_that("test_output_get_animals", {
-  library(dplyr)
+  # Output type
   expect_is(animals_all, "data.frame")
   expect_is(animals_project1, "data.frame")
   expect_is(animals_project2, "data.frame")
   expect_is(animals_projects_multiple, "data.frame")
   expect_is(animals_names_multiple, "data.frame")
   expect_is(animals_project1_name1, "data.frame")
+
+  # Col names
   expect_true(all(names(animals_all) %in% expected_col_names_animals))
   expect_true(all(expected_col_names_animals %in% names(animals_all)))
-  expect_gte(nrow(animals_all), nrow(animals_project1))
-  expect_gte(nrow(animals_all), nrow(animals_project2))
-  expect_gte(nrow(animals_all), nrow(animals_projects_multiple))
-  expect_gte(nrow(animals_all), nrow(animals_names_multiple))
-  expect_gte(nrow(animals_all), nrow(animals_project1_name1))
-  expect_equal(nrow(animals_project2), 309)
   expect_equal(names(animals_all), names(animals_project1))
   expect_equal(names(animals_all), names(animals_project2))
   expect_equal(names(animals_all), names(animals_projects_multiple))
   expect_equal(names(animals_all), names(animals_names_multiple))
   expect_equal(names(animals_all), names(animals_project1_name1))
+
+  # Number of records
+  expect_equal(nrow(animals_project2), 309)
+  expect_gte(nrow(animals_all), nrow(animals_project1))
+  expect_gte(nrow(animals_all), nrow(animals_project2))
+  expect_gte(nrow(animals_all), nrow(animals_projects_multiple))
+  expect_gte(nrow(animals_all), nrow(animals_names_multiple))
+  expect_gte(nrow(animals_all), nrow(animals_project1_name1))
+
+  # scientific_name
   expect_gte(
     animals_all %>% distinct(scientific_name) %>% pull() %>% length(),
     animals_projects_multiple %>% distinct(scientific_name) %>% pull() %>% length()
   )
-  expect_lte(
+  expect_equal(
     animals_projects_multiple %>% distinct(scientific_name) %>% pull() %>% length(),
     (animals_project1 %>% distinct(scientific_name) %>% pull() %>% length() +
       animals_project2 %>% distinct(scientific_name) %>% pull() %>% length())
   )
+
+  # Selected parameter can be found in data
   expect_true(all(projects_multiple %in%
     (animals_names_multiple %>% distinct(animal_project_code) %>% pull())))
   expect_identical(
@@ -134,5 +162,7 @@ testthat::test_that("test_output_get_animals", {
     animals_project1_name1 %>% distinct(animal_project_code) %>% pull(animal_project_code),
     c(project1)
   )
+
+  # Unique IDs
   # expect_equal(nrow(animals_all), nrow(animals_all %>% distinct(pk)))
 })

--- a/tests/testthat/test-get_animals.R
+++ b/tests/testthat/test-get_animals.R
@@ -72,97 +72,85 @@ expected_col_names_animals <- c(
 
 project1 <- "phd_reubens"
 project2 <- "2013_albertkanaal"
-projects_multiple <- c("phd_reubens", "2013_albertkanaal")
-name1 <- "Gadus morhua"
-names_multiple <- c("Gadus morhua", "Sentinel", "Anguilla anguilla")
+project_multiple <- c("2013_albertkanaal", "phd_reubens")
+sciname1 <- "Gadus morhua"
+sciname_multiple <- c("Anguilla anguilla", "Gadus morhua", "Sentinel")
 
 animals_all <- get_animals(con)
-animals_project1 <- get_animals(
-  con,
-  animal_project_code = project1
-)
-animals_project2 <- get_animals(
-  con,
-  animal_project_code = project2
-)
-animals_projects_multiple <- get_animals(
-  con,
-  animal_project_code = projects_multiple
-)
-animals_names_multiple <- get_animals(
-  con,
-  scientific_name = names_multiple
-)
-animals_project1_name1 <- get_animals(
-  con,
-  animal_project_code = project1,
-  scientific_name = name1
-)
+animals_project1 <- get_animals(con, animal_project_code = project1)
+animals_project2 <- get_animals(con, animal_project_code = project2)
+animals_project_multiple <- get_animals(con, animal_project_code = project_multiple)
+animals_sciname_multiple <- get_animals(con, scientific_name = sciname_multiple)
+animals_project1_sciname1 <- get_animals(con, animal_project_code = project1, scientific_name = sciname1)
 
-testthat::test_that("test_input_get_animals", {
-  expect_error(get_animals("I am not a connection"),
+testthat::test_that("Test input", {
+  expect_error(
+    get_animals("not_a_connection"),
     "Not a connection object to database."
   )
-  expect_error(get_animals(
-    con,
-    network_project_code = "very_bad_project"
-  ))
-  expect_error(get_animals(
-    con,
-    network_project_code = c("thornton", "very_bad_project")
-  ))
+  expect_error(
+    get_animals(con, network_project_code = "not_a_project")
+  )
+  expect_error(
+    get_animals(con, network_project_code = c("thornton", "not_a_project"))
+  )
 })
 
-
-testthat::test_that("test_output_get_animals", {
-  # Output type
+testthat::test_that("Test output type", {
   expect_is(animals_all, "data.frame")
   expect_is(animals_project1, "data.frame")
   expect_is(animals_project2, "data.frame")
-  expect_is(animals_projects_multiple, "data.frame")
-  expect_is(animals_names_multiple, "data.frame")
-  expect_is(animals_project1_name1, "data.frame")
+  expect_is(animals_project_multiple, "data.frame")
+  expect_is(animals_sciname_multiple, "data.frame")
+  expect_is(animals_project1_sciname1, "data.frame")
+})
 
-  # Col names
+testthat::test_that("Test column names", {
   expect_true(all(names(animals_all) %in% expected_col_names_animals))
   expect_true(all(expected_col_names_animals %in% names(animals_all)))
   expect_equal(names(animals_all), names(animals_project1))
   expect_equal(names(animals_all), names(animals_project2))
-  expect_equal(names(animals_all), names(animals_projects_multiple))
-  expect_equal(names(animals_all), names(animals_names_multiple))
-  expect_equal(names(animals_all), names(animals_project1_name1))
+  expect_equal(names(animals_all), names(animals_project_multiple))
+  expect_equal(names(animals_all), names(animals_sciname_multiple))
+  expect_equal(names(animals_all), names(animals_project1_sciname1))
+})
 
-  # Number of records
+testthat::test_that("Test number of records", {
   expect_equal(nrow(animals_project2), 309)
   expect_gte(nrow(animals_all), nrow(animals_project1))
   expect_gte(nrow(animals_all), nrow(animals_project2))
-  expect_gte(nrow(animals_all), nrow(animals_projects_multiple))
-  expect_gte(nrow(animals_all), nrow(animals_names_multiple))
-  expect_gte(nrow(animals_all), nrow(animals_project1_name1))
+  expect_gte(nrow(animals_all), nrow(animals_project_multiple))
+  expect_gte(nrow(animals_all), nrow(animals_sciname_multiple))
+  expect_gte(nrow(animals_all), nrow(animals_project1_sciname1))
+})
 
-  # scientific_name
-  expect_gte(
-    animals_all %>% distinct(scientific_name) %>% pull() %>% length(),
-    animals_projects_multiple %>% distinct(scientific_name) %>% pull() %>% length()
-  )
+testthat::test_that("Test if data is filtered on paramater", {
   expect_equal(
-    animals_projects_multiple %>% distinct(scientific_name) %>% pull() %>% length(),
-    (animals_project1 %>% distinct(scientific_name) %>% pull() %>% length() +
-      animals_project2 %>% distinct(scientific_name) %>% pull() %>% length())
-  )
-
-  # Selected parameter can be found in data
-  expect_true(all(projects_multiple %in%
-    (animals_names_multiple %>% distinct(animal_project_code) %>% pull())))
-  expect_identical(
-    animals_project1_name1 %>% distinct(scientific_name) %>% pull(scientific_name),
-    c(name1)
-  )
-  expect_identical(
-    animals_project1_name1 %>% distinct(animal_project_code) %>% pull(animal_project_code),
+    animals_project1 %>% distinct(animal_project_code) %>% pull(),
     c(project1)
   )
-
-  # Unique IDs
-  # expect_equal(nrow(animals_all), nrow(animals_all %>% distinct(pk)))
+  expect_equal(
+    animals_project2 %>% distinct(animal_project_code) %>% pull(),
+    c(project2)
+  )
+  expect_equal(
+    animals_project_multiple %>% distinct(animal_project_code) %>% arrange(animal_project_code) %>% pull(),
+    c(project_multiple)
+  )
+  expect_equal(
+    animals_sciname_multiple %>% distinct(scientific_name) %>% arrange(scientific_name) %>% pull(),
+    c(sciname_multiple)
+  )
+  expect_equal(
+    animals_project1_sciname1 %>% distinct(animal_project_code) %>% pull(),
+    c(project1)
+  )
+  expect_equal(
+    animals_project1_sciname1 %>% distinct(scientific_name) %>% pull(),
+    c(sciname1)
+  )
 })
+
+# testthat::test_that("Test unique ids", {
+#   expect_equal(nrow(animals_all), nrow(animals_all %>% distinct(pk)))
+# })

--- a/tests/testthat/test-get_animals.R
+++ b/tests/testthat/test-get_animals.R
@@ -117,11 +117,13 @@ testthat::test_that("Test column names", {
 
 testthat::test_that("Test number of records", {
   expect_equal(nrow(animals_project2), 309)
-  expect_gte(nrow(animals_all), nrow(animals_project1))
-  expect_gte(nrow(animals_all), nrow(animals_project2))
-  expect_gte(nrow(animals_all), nrow(animals_project_multiple))
-  expect_gte(nrow(animals_all), nrow(animals_sciname_multiple))
-  expect_gte(nrow(animals_all), nrow(animals_project1_sciname1))
+  expect_gt(nrow(animals_all), nrow(animals_project1))
+  expect_gt(nrow(animals_all), nrow(animals_project2))
+  expect_gt(nrow(animals_all), nrow(animals_project_multiple))
+  expect_equal(nrow(animals_project_multiple), nrow(animals_project1) + nrow(animals_project2))
+  expect_gt(nrow(animals_all), nrow(animals_sciname_multiple))
+  expect_gt(nrow(animals_all), nrow(animals_project1_sciname1))
+  expect_gt(nrow(animals_project1), nrow(animals_project1_sciname1))
 })
 
 testthat::test_that("Test if data is filtered on paramater", {

--- a/tests/testthat/test-get_deployments.R
+++ b/tests/testthat/test-get_deployments.R
@@ -97,10 +97,10 @@ testthat::test_that("Test column names", {
 })
 
 testthat::test_that("Test number of records", {
-  expect_gte(nrow(deployments_all), nrow(deployments_project1))
-  expect_gte(nrow(deployments_all), nrow(deployments_project_multiple))
-  expect_gte(nrow(deployments_project_multiple), nrow(deployments_project1))
-  expect_gte(nrow(deployments_status_multiple), nrow(deployments_status1))
+  expect_gt(nrow(deployments_all), nrow(deployments_project1))
+  expect_gt(nrow(deployments_all), nrow(deployments_project_multiple))
+  expect_gt(nrow(deployments_project_multiple), nrow(deployments_project1))
+  expect_gt(nrow(deployments_status_multiple), nrow(deployments_status1))
   expect_gte(nrow(deployments_project1_openfalse), nrow(deployments_project1))
 })
 

--- a/tests/testthat/test-get_detections.R
+++ b/tests/testthat/test-get_detections.R
@@ -32,9 +32,8 @@ expected_col_names_detections <- c(
 
 start_date <- "2011"
 end_date <- "2011-02-01"
-start <- check_date_time(start_date, "start_date")
-end <- check_date_time(end_date, "end_date")
-limit <- 5
+start_date_full <- as.POSIXct(check_date_time(start_date, "start_date"), tz = "UTC")
+end_date_full <- as.POSIXct(check_date_time(end_date, "end_date"), tz = "UTC")
 animal_project <- "phd_reubens"
 network_project <- "thornton"
 tag_id <- "A69-1303-65302"
@@ -42,122 +41,170 @@ receiver_id <- "VR2W-122360"
 scientific_name <- "Anguilla anguilla"
 station_name <- "R03"
 
-detections_limit5 <- get_detections(con, start_date = start_date, limit = 5)
-detections_start_end <- get_detections(con,
-  animal_project_code = animal_project,
-  network_project_code = network_project, start_date = start_date,
-  end_date = end_date, limit = limit,
-  tag_id = tag_id
+detections_limit <- get_detections(
+  con,
+  start_date = start_date,
+  limit = TRUE
 )
-detections_station <- get_detections(con,
+detections_start_end <- get_detections(
+  con,
+  animal_project_code = animal_project,
+  network_project_code = network_project,
+  start_date = start_date,
+  end_date = end_date,
+  tag_id = tag_id,
+  limit = FALSE
+)
+detections_station <- get_detections(
+  con,
   animal_project_code = animal_project,
   network_project_code = network_project,
   station_name = station_name,
-  limit = limit, tag_id = tag_id
+  tag_id = tag_id,
+  limit = FALSE
+)
+detections_tag <- get_detections(
+  con,
+  tag_id = tag_id,
+  limit = TRUE
+)
+detections_receiver <- get_detections(
+  con,
+  receiver_id = receiver_id,
+  limit = TRUE
+)
+detections_name <- get_detections(
+  con,
+  scientific_name = scientific_name,
+  limit = TRUE
 )
 
-detections_tag <- get_detections(con, tag_id = tag_id, limit = limit)
-# detections_receiver <- get_detections(con, receiver_id = receiver_id, limit = limit)
-detections_name <- get_detections(con, scientific_name = scientific_name, limit = limit)
-
 testthat::test_that("test_input_get_detections", {
-  expect_error(
-    get_detections("I am not a connection"),
+  expect_error(get_detections("I am not a connection"),
     "Not a connection object to database."
   )
-  expect_error(get_detections(con, network_project_code = "very_bad_project"))
-  expect_error(get_detections(con, network_project_code = c(
-    "thornton",
-    "very_bad_project"
-  )))
-  expect_error(get_detections(con,
+  expect_error(get_detections(
+    con,
+    network_project_code = "very_bad_project"
+  ))
+  expect_error(get_detections(
+    con,
+    network_project_code = c("thornton", "very_bad_project")
+  ))
+  expect_error(get_detections(
+    con,
     animal_project_code = "very_bad_project",
     network_project_code = "thornton"
   ))
-  expect_error(get_detections(con,
+  expect_error(get_detections(
+    con,
     animal_project_code = c("phd_reubens", "i_am_bad"),
     network_project_code = "thornton"
   ))
-  expect_error(get_detections(con,
+  expect_error(get_detections(
+    con,
     animal_project_code = "phd_reubens",
     network_project_code = "thornton",
     start_date = "bad_date"
   ))
-  expect_error(get_detections(con,
+  expect_error(get_detections(
+    con,
     animal_project_code = "phd_reubens",
     network_project_code = "thornton",
-    start_date = "2011", end_date = "bad_brrrr"
+    start_date = "2011",
+    end_date = "bad_brrrr"
   ))
-  expect_error(get_detections(con,
+  expect_error(get_detections(
+    con,
     animal_project_code = "phd_reubens",
     network_project_code = "thornton",
-    start_date = "2011", end_date = "bad_brrrr"
+    start_date = "2011",
+    end_date = "bad_brrrr"
   ))
-  expect_error(get_detections(con,
+  expect_error(get_detections(
+    con,
     animal_project_code = "phd_reubens",
     network_project_code = "thornton",
     station_name = "no_way"
   ))
-  expect_error(get_detections(con,
+  expect_error(get_detections(
+    con,
     animal_project_code = "phd_reubens",
     network_project_code = "thornton",
     station_name = c("R03", "no_way")
   ))
-  expect_error(get_detections(con,
+  expect_error(get_detections(
+    con,
     animal_project_code = "phd_reubens",
     network_project_code = "thornton",
     tag_id = c("R03", "no_way")
   ))
-  expect_error(get_detections(con,
+  expect_error(get_detections(
+    con,
     animal_project_code = "phd_reubens",
     network_project_code = "thornton",
     receiver_id = c("superraar")
   ))
-  expect_error(get_detections(con, scientific_name = c("I am not an animal")))
+  expect_error(get_detections(
+    con,
+    scientific_name = c("I am not an animal")
+  ))
 })
 
 testthat::test_that("test_output_get_detections", {
-  library(dplyr)
-  expect_is(detections_limit5, "data.frame")
+  # Output type
+  expect_is(detections_limit, "data.frame")
   expect_is(detections_start_end, "data.frame")
   expect_is(detections_station, "data.frame")
   expect_is(detections_tag, "data.frame")
-  expect_true(all(names(detections_limit5) %in% expected_col_names_detections))
-  expect_true(all(expected_col_names_detections %in% names(detections_limit5)))
-  expect_equal(nrow(detections_limit5), 5)
-  expect_equal(names(detections_limit5), names(detections_start_end))
-  expect_equal(names(detections_limit5), names(detections_station))
-  expect_equal(names(detections_limit5), names(detections_tag))
-  # expect_equal(names(detections_limit5), names(detections_receiver))
-  expect_equal(names(detections_limit5), names(detections_name))
-  expect_true(detections_limit5 %>%
-    select(date_time) %>%
+  expect_is(detections_name, "data.frame")
+
+  # Col names
+  expect_true(all(names(detections_limit) %in% expected_col_names_detections))
+  expect_true(all(expected_col_names_detections %in% names(detections_limit)))
+  expect_equal(names(detections_limit), names(detections_start_end))
+  expect_equal(names(detections_limit), names(detections_station))
+  expect_equal(names(detections_limit), names(detections_tag))
+  expect_equal(names(detections_limit), names(detections_receiver))
+  expect_equal(names(detections_limit), names(detections_name))
+
+  # Number of records
+  expect_equal(nrow(detections_limit), 100)
+  expect_gte(nrow(detections_start_end), nrow(detections_limit))
+  expect_gte(nrow(detections_station), nrow(detections_limit))
+  expect_lte(nrow(detections_tag), nrow(detections_limit))
+  expect_lte(nrow(detections_receiver), nrow(detections_limit))
+  expect_lte(nrow(detections_name), nrow(detections_limit))
+
+  # Minimum date in data >= start_date
+  expect_gte(detections_limit %>%
     summarize(min_date_time = min(date_time)) %>%
-    pull(min_date_time) > start)
-  expect_true(detections_start_end %>%
-    select(date_time) %>%
+    pull(min_date_time), start_date_full)
+  expect_gte(detections_start_end %>%
     summarize(min_date_time = min(date_time)) %>%
-    pull(min_date_time) > start)
-  expect_true(detections_start_end %>%
-    select(date_time) %>%
+    pull(min_date_time), start_date_full)
+
+  # Maximum date in data <= end_date
+  expect_lte(detections_start_end %>%
     summarize(max_date_time = max(date_time)) %>%
-    pull(max_date_time) < end)
+    pull(max_date_time), end_date_full)
+
+  # Selected parameter can be found in data
   expect_true(detections_start_end %>%
     distinct(animal_project_code) %>%
     pull() == animal_project)
   expect_true(detections_start_end %>%
     distinct(network_project_code) %>%
     pull() == network_project)
-  expect_lte(detections_start_end %>% nrow(), limit)
   expect_true(detections_station %>%
     distinct(station_name) %>%
     pull() == station_name)
   expect_true(detections_tag %>%
     distinct(tag_id) %>%
     pull() == tag_id)
-  #  expect_true(detections_receiver %>%
-  #                distinct(receiver_id) %>%
-  #                pull() == receiver_id)
+  expect_true(detections_receiver %>%
+    distinct(receiver_id) %>%
+    pull() == receiver_id)
   expect_true(detections_name %>%
     distinct(scientific_name) %>%
     pull() == scientific_name)

--- a/tests/testthat/test-get_detections.R
+++ b/tests/testthat/test-get_detections.R
@@ -117,8 +117,8 @@ testthat::test_that("Test column names", {
 
 testthat::test_that("Test number of records", {
   expect_equal(nrow(detections_limit), 100)
-  expect_gte(nrow(detections_start_end), nrow(detections_limit))
-  expect_gte(nrow(detections_station), nrow(detections_limit))
+  expect_gt(nrow(detections_start_end), nrow(detections_limit))
+  expect_gt(nrow(detections_station), nrow(detections_limit))
   expect_lte(nrow(detections_tag), nrow(detections_limit))
   expect_lte(nrow(detections_receiver), nrow(detections_limit))
   expect_lte(nrow(detections_sciname), nrow(detections_limit))

--- a/tests/testthat/test-get_detections.R
+++ b/tests/testthat/test-get_detections.R
@@ -34,178 +34,146 @@ start_date <- "2011"
 end_date <- "2011-02-01"
 start_date_full <- as.POSIXct(check_date_time(start_date, "start_date"), tz = "UTC")
 end_date_full <- as.POSIXct(check_date_time(end_date, "end_date"), tz = "UTC")
+station_name <- "R03"
 animal_project <- "phd_reubens"
 network_project <- "thornton"
 tag_id <- "A69-1303-65302"
 receiver_id <- "VR2W-122360"
-scientific_name <- "Anguilla anguilla"
-station_name <- "R03"
+sciname <- "Anguilla anguilla"
 
-detections_limit <- get_detections(
-  con,
-  start_date = start_date,
-  limit = TRUE
-)
+detections_limit <- get_detections(con, limit = TRUE)
 detections_start_end <- get_detections(
   con,
-  animal_project_code = animal_project,
-  network_project_code = network_project,
-  start_date = start_date,
-  end_date = end_date,
-  tag_id = tag_id,
-  limit = FALSE
+  animal_project_code = animal_project, network_project_code = network_project,
+  start_date = start_date, end_date = end_date, tag_id = tag_id, limit = FALSE
 )
 detections_station <- get_detections(
   con,
-  animal_project_code = animal_project,
-  network_project_code = network_project,
-  station_name = station_name,
-  tag_id = tag_id,
-  limit = FALSE
+  animal_project_code = animal_project, network_project_code = network_project,
+  station_name = station_name, tag_id = tag_id, limit = FALSE
 )
-detections_tag <- get_detections(
-  con,
-  tag_id = tag_id,
-  limit = TRUE
-)
-detections_receiver <- get_detections(
-  con,
-  receiver_id = receiver_id,
-  limit = TRUE
-)
-detections_name <- get_detections(
-  con,
-  scientific_name = scientific_name,
-  limit = TRUE
-)
+detections_tag <- get_detections(con, tag_id = tag_id, limit = TRUE)
+detections_receiver <- get_detections(con, receiver_id = receiver_id, limit = TRUE)
+detections_sciname <- get_detections(con, scientific_name = sciname, limit = TRUE)
 
-testthat::test_that("test_input_get_detections", {
-  expect_error(get_detections("I am not a connection"),
+testthat::test_that("Test input", {
+  expect_error(
+    get_detections("not_a_connection"),
     "Not a connection object to database."
   )
-  expect_error(get_detections(
-    con,
-    network_project_code = "very_bad_project"
-  ))
-  expect_error(get_detections(
-    con,
-    network_project_code = c("thornton", "very_bad_project")
-  ))
-  expect_error(get_detections(
-    con,
-    animal_project_code = "very_bad_project",
-    network_project_code = "thornton"
-  ))
-  expect_error(get_detections(
-    con,
-    animal_project_code = c("phd_reubens", "i_am_bad"),
-    network_project_code = "thornton"
-  ))
-  expect_error(get_detections(
-    con,
-    animal_project_code = "phd_reubens",
-    network_project_code = "thornton",
-    start_date = "bad_date"
-  ))
-  expect_error(get_detections(
-    con,
-    animal_project_code = "phd_reubens",
-    network_project_code = "thornton",
-    start_date = "2011",
-    end_date = "bad_brrrr"
-  ))
-  expect_error(get_detections(
-    con,
-    animal_project_code = "phd_reubens",
-    network_project_code = "thornton",
-    start_date = "2011",
-    end_date = "bad_brrrr"
-  ))
-  expect_error(get_detections(
-    con,
-    animal_project_code = "phd_reubens",
-    network_project_code = "thornton",
-    station_name = "no_way"
-  ))
-  expect_error(get_detections(
-    con,
-    animal_project_code = "phd_reubens",
-    network_project_code = "thornton",
-    station_name = c("R03", "no_way")
-  ))
-  expect_error(get_detections(
-    con,
-    animal_project_code = "phd_reubens",
-    network_project_code = "thornton",
-    tag_id = c("R03", "no_way")
-  ))
-  expect_error(get_detections(
-    con,
-    animal_project_code = "phd_reubens",
-    network_project_code = "thornton",
-    receiver_id = c("superraar")
-  ))
-  expect_error(get_detections(
-    con,
-    scientific_name = c("I am not an animal")
-  ))
+  expect_error(
+    get_detections(con, network_project_code = "not_a_project")
+  )
+  expect_error(
+    get_detections(con, network_project_code = c("thornton", "not_a_project"))
+  )
+  expect_error(
+    get_detections(con, animal_project_code = "not_a_project", network_project_code = "thornton")
+  )
+  expect_error(
+    get_detections(con, animal_project_code = c("phd_reubens", "not_a_project"), network_project_code = "thornton")
+  )
+  expect_error(
+    get_detections(con, animal_project_code = "phd_reubens", network_project_code = "thornton", start_date = "not_a_date")
+  )
+  expect_error(
+    get_detections(con, animal_project_code = "phd_reubens", network_project_code = "thornton", start_date = "2011", end_date = "not_a_date")
+  )
+  expect_error(
+    get_detections(con, animal_project_code = "phd_reubens", network_project_code = "thornton", station_name = "not_a_station")
+  )
+  expect_error(
+    get_detections(con, animal_project_code = "phd_reubens", network_project_code = "thornton", station_name = c("R03", "not_a_station"))
+  )
+  expect_error(
+    get_detections(con, animal_project_code = "phd_reubens", network_project_code = "thornton", tag_id = c("R03", "not_a_tag"))
+  )
+  expect_error(
+    get_detections(con, animal_project_code = "phd_reubens", network_project_code = "thornton", receiver_id = c("not_a_receiver"))
+  )
+  expect_error(
+    get_detections(con, scientific_name = c("not_a_sciname"))
+  )
 })
 
-testthat::test_that("test_output_get_detections", {
-  # Output type
+testthat::test_that("Test output type", {
   expect_is(detections_limit, "data.frame")
   expect_is(detections_start_end, "data.frame")
   expect_is(detections_station, "data.frame")
   expect_is(detections_tag, "data.frame")
-  expect_is(detections_name, "data.frame")
+  expect_is(detections_receiver, "data.frame")
+  expect_is(detections_sciname, "data.frame")
+})
 
-  # Col names
+testthat::test_that("Test column names", {
   expect_true(all(names(detections_limit) %in% expected_col_names_detections))
   expect_true(all(expected_col_names_detections %in% names(detections_limit)))
   expect_equal(names(detections_limit), names(detections_start_end))
   expect_equal(names(detections_limit), names(detections_station))
   expect_equal(names(detections_limit), names(detections_tag))
   expect_equal(names(detections_limit), names(detections_receiver))
-  expect_equal(names(detections_limit), names(detections_name))
+  expect_equal(names(detections_limit), names(detections_sciname))
+})
 
-  # Number of records
+testthat::test_that("Test number of records", {
   expect_equal(nrow(detections_limit), 100)
   expect_gte(nrow(detections_start_end), nrow(detections_limit))
   expect_gte(nrow(detections_station), nrow(detections_limit))
   expect_lte(nrow(detections_tag), nrow(detections_limit))
   expect_lte(nrow(detections_receiver), nrow(detections_limit))
-  expect_lte(nrow(detections_name), nrow(detections_limit))
+  expect_lte(nrow(detections_sciname), nrow(detections_limit))
+})
 
-  # Minimum date in data >= start_date
-  expect_gte(detections_limit %>%
-    summarize(min_date_time = min(date_time)) %>%
-    pull(min_date_time), start_date_full)
-  expect_gte(detections_start_end %>%
-    summarize(min_date_time = min(date_time)) %>%
-    pull(min_date_time), start_date_full)
+testthat::test_that("Test date range", {
+  expect_gte(
+    detections_start_end %>% summarize(min_date_time = min(date_time)) %>% pull(min_date_time),
+    start_date_full
+  )
+  expect_lte(
+    detections_start_end %>% summarize(max_date_time = max(date_time)) %>% pull(max_date_time),
+    end_date_full
+  )
+})
 
-  # Maximum date in data <= end_date
-  expect_lte(detections_start_end %>%
-    summarize(max_date_time = max(date_time)) %>%
-    pull(max_date_time), end_date_full)
-
-  # Selected parameter can be found in data
-  expect_true(detections_start_end %>%
-    distinct(animal_project_code) %>%
-    pull() == animal_project)
-  expect_true(detections_start_end %>%
-    distinct(network_project_code) %>%
-    pull() == network_project)
-  expect_true(detections_station %>%
-    distinct(station_name) %>%
-    pull() == station_name)
-  expect_true(detections_tag %>%
-    distinct(tag_id) %>%
-    pull() == tag_id)
-  expect_true(detections_receiver %>%
-    distinct(receiver_id) %>%
-    pull() == receiver_id)
-  expect_true(detections_name %>%
-    distinct(scientific_name) %>%
-    pull() == scientific_name)
+testthat::test_that("Test if data is filtered on paramater", {
+  expect_equal(
+    detections_start_end %>% distinct(animal_project_code) %>% pull(),
+    c(animal_project)
+  )
+  expect_equal(
+    detections_start_end %>% distinct(network_project_code) %>% pull(),
+    c(network_project)
+  )
+  expect_equal(
+    detections_start_end %>% distinct(tag_id) %>% pull(),
+    c(tag_id)
+  )
+  expect_equal(
+    detections_station %>% distinct(animal_project_code) %>% pull(),
+    c(animal_project)
+  )
+  expect_equal(
+    detections_station %>% distinct(network_project_code) %>% pull(),
+    c(network_project)
+  )
+  expect_equal(
+    detections_station %>% distinct(tag_id) %>% pull(),
+    c(tag_id)
+  )
+  expect_equal(
+    detections_station %>% distinct(station_name) %>% pull(),
+    c(station_name)
+  )
+  expect_equal(
+    detections_tag %>% distinct(tag_id) %>% pull(),
+    c(tag_id)
+  )
+  expect_equal(
+    detections_receiver %>% distinct(receiver_id) %>% pull(),
+    c(receiver_id)
+  )
+  expect_equal(
+    detections_sciname %>% distinct(scientific_name) %>% pull(),
+    c(sciname)
+  )
 })

--- a/tests/testthat/test-get_projects.R
+++ b/tests/testthat/test-get_projects.R
@@ -60,10 +60,7 @@ testthat::test_that("Test column names", {
 testthat::test_that("Test number of records", {
   expect_gte(nrow(projects_all), nrow(projects_animal))
   expect_gte(nrow(projects_all), nrow(projects_network))
-  expect_equal(
-    nrow(projects_all),
-    nrow(projects_network) + nrow(projects_animal)
-  )
+  expect_equal(nrow(projects_all), nrow(projects_network) + nrow(projects_animal))
 })
 
 testthat::test_that("Test unique ids", {

--- a/tests/testthat/test-get_projects.R
+++ b/tests/testthat/test-get_projects.R
@@ -24,44 +24,49 @@ projects_all <- get_projects(con)
 projects_animal <- get_projects(con, project_type = "animal")
 projects_network <- get_projects(con, project_type = "network")
 
-testthat::test_that("test_input_get_projects", {
-  expect_error(get_projects("I am not a connection"),
+testthat::test_that("Test input", {
+  expect_error(
+    get_projects("not_a_connection"),
     "Not a connection object to database."
   )
-  expect_error(get_projects(con, project_type = "bad_project_type"),
+  expect_error(
+    get_projects(con, project_type = "not_a_project_type"),
     paste(
-      "Not valid input value(s) for project_type input",
+      "Invalid value(s) for project_type",
       "argument.\nValid inputs are: animal and network."
     ),
     fixed = TRUE
   )
-  expect_error(get_projects(con, prj_type = "bad_project_type"),
-    "unused argument (prj_type = \"bad_project_type\")",
+  expect_error(
+    get_projects(con, prj_type = "not_a_project_type"),
+    "unused argument (prj_type = \"not_a_project_type\")",
     fixed = TRUE
   )
 })
 
-testthat::test_that("test_output_get_projects", {
-  # Output type
+testthat::test_that("Test output type", {
   expect_is(projects_all, "data.frame")
   expect_is(projects_animal, "data.frame")
   expect_is(projects_network, "data.frame")
+})
 
-  # Col names
+testthat::test_that("Test column names", {
   expect_true(all(names(projects_all) %in% expected_col_names_projects))
   expect_true(all(expected_col_names_projects %in% names(projects_all)))
   expect_equal(names(projects_all), names(projects_animal))
   expect_equal(names(projects_animal), names(projects_network))
+})
 
-  # Number of records
+testthat::test_that("Test number of records", {
   expect_gte(nrow(projects_all), nrow(projects_animal))
   expect_gte(nrow(projects_all), nrow(projects_network))
-  expect_equivalent(
+  expect_equal(
     nrow(projects_all),
     nrow(projects_network) + nrow(projects_animal)
   )
+})
 
-  # Unique IDs
+testthat::test_that("Test unique ids", {
   expect_equal(nrow(projects_all), nrow(projects_all %>% distinct(pk)))
   # expect_equal(nrow(projects_all), nrow(projects_all %>% distinct(project_code)))
 })

--- a/tests/testthat/test-get_projects.R
+++ b/tests/testthat/test-get_projects.R
@@ -25,8 +25,7 @@ projects_animal <- get_projects(con, project_type = "animal")
 projects_network <- get_projects(con, project_type = "network")
 
 testthat::test_that("test_input_get_projects", {
-  expect_error(
-    get_projects("I am not a connection"),
+  expect_error(get_projects("I am not a connection"),
     "Not a connection object to database."
   )
   expect_error(get_projects(con, project_type = "bad_project_type"),
@@ -43,19 +42,26 @@ testthat::test_that("test_input_get_projects", {
 })
 
 testthat::test_that("test_output_get_projects", {
+  # Output type
   expect_is(projects_all, "data.frame")
   expect_is(projects_animal, "data.frame")
   expect_is(projects_network, "data.frame")
+
+  # Col names
   expect_true(all(names(projects_all) %in% expected_col_names_projects))
   expect_true(all(expected_col_names_projects %in% names(projects_all)))
+  expect_equal(names(projects_all), names(projects_animal))
+  expect_equal(names(projects_animal), names(projects_network))
+
+  # Number of records
   expect_gte(nrow(projects_all), nrow(projects_animal))
   expect_gte(nrow(projects_all), nrow(projects_network))
   expect_equivalent(
     nrow(projects_all),
     nrow(projects_network) + nrow(projects_animal)
   )
-  expect_equal(names(projects_all), names(projects_animal))
-  expect_equal(names(projects_animal), names(projects_network))
+
+  # Unique IDs
   expect_equal(nrow(projects_all), nrow(projects_all %>% distinct(pk)))
   # expect_equal(nrow(projects_all), nrow(projects_all %>% distinct(project_code)))
 })

--- a/tests/testthat/test-get_receivers.R
+++ b/tests/testthat/test-get_receivers.R
@@ -33,22 +33,54 @@ expected_col_names_receivers <- c(
   "ar_tilt_after_deploy"
 )
 
+receiver1 <- "VR2-4842c"
+receiver_multiple <- c("VR2AR-545719", "VR2AR-545720")
+
 receivers_all <- get_receivers(con)
+receivers_receiver1 <- get_receivers(con, receiver_id = receiver1)
+receivers_receiver_multiple <- get_receivers(con, receiver_id = receiver_multiple)
 
 testthat::test_that("Test input", {
   expect_error(
     get_receivers("not_a_connection"),
     "Not a connection object to database."
   )
+  expect_error(
+    get_receivers(con, receiver_id = "not_a_receiver_id")
+  )
+  expect_error(
+    get_receivers(con, receiver_id = c("VR2AR-545719", "not_a_receiver_id"))
+  )
 })
 
 testthat::test_that("Test output type", {
   expect_is(receivers_all, "data.frame")
+  expect_is(receivers_receiver1, "data.frame")
+  expect_is(receivers_receiver_multiple, "data.frame")
 })
 
 testthat::test_that("Test column names", {
   expect_true(all(names(receivers_all) %in% expected_col_names_receivers))
   expect_true(all(expected_col_names_receivers %in% names(receivers_all)))
+  expect_equal(names(receivers_all), names(receivers_receiver1))
+  expect_equal(names(receivers_all), names(receivers_receiver_multiple))
+})
+
+testthat::test_that("Test number of records", {
+  expect_gt(nrow(receivers_all), nrow(receivers_receiver1))
+  expect_equal(nrow(receivers_receiver1), 1)
+  expect_equal(nrow(receivers_receiver_multiple), 2)
+})
+
+testthat::test_that("Test if data is filtered on paramater", {
+  expect_equal(
+    receivers_receiver1 %>% distinct(receiver_id) %>% pull(),
+    c(receiver1)
+  )
+  expect_equal(
+    receivers_receiver_multiple %>% distinct(receiver_id) %>% arrange(receiver_id) %>% pull(),
+    receiver_multiple
+  )
 })
 
 testthat::test_that("Test unique ids", {

--- a/tests/testthat/test-get_receivers.R
+++ b/tests/testthat/test-get_receivers.R
@@ -36,16 +36,20 @@ expected_col_names_receivers <- c(
 receivers_all <- get_receivers(con)
 
 testthat::test_that("test_input_get_receivers", {
-  expect_error(
-    get_receivers("I am not a connection"),
+  expect_error(get_receivers("I am not a connection"),
     "Not a connection object to database."
   )
 })
 
 testthat::test_that("test_output_get_receivers", {
+  # Output type
   expect_is(receivers_all, "data.frame")
+
+  # Col names
   expect_true(all(names(receivers_all) %in% expected_col_names_receivers))
   expect_true(all(expected_col_names_receivers %in% names(receivers_all)))
+
+  # Unique IDs
   expect_equal(nrow(receivers_all), nrow(receivers_all %>% distinct(pk)))
   expect_equal(nrow(receivers_all), nrow(receivers_all %>% distinct(receiver_id)))
 })

--- a/tests/testthat/test-get_receivers.R
+++ b/tests/testthat/test-get_receivers.R
@@ -35,21 +35,23 @@ expected_col_names_receivers <- c(
 
 receivers_all <- get_receivers(con)
 
-testthat::test_that("test_input_get_receivers", {
-  expect_error(get_receivers("I am not a connection"),
+testthat::test_that("Test input", {
+  expect_error(
+    get_receivers("not_a_connection"),
     "Not a connection object to database."
   )
 })
 
-testthat::test_that("test_output_get_receivers", {
-  # Output type
+testthat::test_that("Test output type", {
   expect_is(receivers_all, "data.frame")
+})
 
-  # Col names
+testthat::test_that("Test column names", {
   expect_true(all(names(receivers_all) %in% expected_col_names_receivers))
   expect_true(all(expected_col_names_receivers %in% names(receivers_all)))
+})
 
-  # Unique IDs
+testthat::test_that("Test unique ids", {
   expect_equal(nrow(receivers_all), nrow(receivers_all %>% distinct(pk)))
   expect_equal(nrow(receivers_all), nrow(receivers_all %>% distinct(receiver_id)))
 })

--- a/tests/testthat/test-get_tags.R
+++ b/tests/testthat/test-get_tags.R
@@ -52,10 +52,13 @@ expected_col_names_tags <- c(
   "step4_acceleration_duration"
 )
 
+tag1 <- "A69-1303-65313" # A sentinel tag with 2 records
+tag_multiple <- c("A69-1601-1705", "A69-1601-1707")
+
 tags_all <- get_tags(con)
 tags_all_ref <- get_tags(con, include_ref_tags = TRUE)
-tags_tag1 <- get_tags(con, tag_id = "A69-1303-65313") # A sentinel tag with 2 records
-tags_tag_multiple <- get_tags(con, tag_id = c("A69-1601-1705", "A69-1601-1707"))
+tags_tag1 <- get_tags(con, tag_id = tag1)
+tags_tag_multiple <- get_tags(con, tag_id = tag_multiple)
 
 testthat::test_that("Test input", {
   expect_error(
@@ -97,11 +100,11 @@ testthat::test_that("Test number of records", {
 testthat::test_that("Test if data is filtered on paramater", {
   expect_equal(
     tags_tag1 %>% distinct(tag_id) %>% pull(),
-    c("A69-1303-65313")
+    c(tag1)
   )
   expect_equal(
     tags_tag_multiple %>% distinct(tag_id) %>% arrange(tag_id) %>% pull(),
-    c("A69-1601-1705", "A69-1601-1707")
+    tag_multiple
   )
 })
 

--- a/tests/testthat/test-get_tags.R
+++ b/tests/testthat/test-get_tags.R
@@ -53,65 +53,59 @@ expected_col_names_tags <- c(
 )
 
 tags_all <- get_tags(con)
-tags_project1 <- get_tags(
-  con,
-  animal_project_code = "phd_reubens"
-)
-tags_projects_multiple <- get_tags(
-  con,
-  animal_project_code = c("phd_reubens", "2012_leopoldkanaal")
-)
-tags_project1_ref <- get_tags(
-  con,
-  animal_project_code = "phd_reubens",
-  include_reference_tags = TRUE
-)
+tags_all_ref <- get_tags(con, include_ref_tags = TRUE)
+tags_tag1 <- get_tags(con, tag_id = "A69-1303-65313") # A sentinel tag with 2 records
+tags_tag_multiple <- get_tags(con, tag_id = c("A69-1601-1705", "A69-1601-1707"))
 
-testthat::test_that("test_input_get_tags", {
-  expect_error(get_tags("I am not a connection"),
+testthat::test_that("Test input", {
+  expect_error(
+    get_tags("not_a_connection"),
     "Not a connection object to database."
   )
-  expect_error(get_tags(
-    con,
-    animal_project_code = "very_bad_project"
-  ))
-  expect_error(get_tags(
-    con,
-    animal_project_code = c("phd_reubens", "very_bad_project")
-  ))
-  expect_error(get_tags(
-    con,
-    include_reference_tags = "not logical"
-  ))
+  expect_error(
+    get_tags(con, tag_id = "not_a_tag_id")
+  )
+  expect_error(
+    get_tags(con, tag_id = c("A69-1601-1705", "not_a_tag_id"))
+  )
+  expect_error(
+    get_tags(con, include_ref_tags = "not_a_logical")
+  )
 })
 
-testthat::test_that("test_output_get_tags", {
-  # Output type
+testthat::test_that("Test output type", {
   expect_is(tags_all, "data.frame")
-  expect_is(tags_project1, "data.frame")
-  expect_is(tags_projects_multiple, "data.frame")
-  expect_is(tags_project1_ref, "data.frame")
+  expect_is(tags_all_ref, "data.frame")
+  expect_is(tags_tag1, "data.frame")
+  expect_is(tags_tag_multiple, "data.frame")
+})
 
-  # Col names
+testthat::test_that("Test column names", {
   expect_true(all(names(tags_all) %in% expected_col_names_tags))
   expect_true(all(expected_col_names_tags %in% names(tags_all)))
-  expect_equal(names(tags_all), names(tags_project1))
-  expect_equal(names(tags_all), names(tags_projects_multiple))
-  expect_equal(names(tags_all), names(tags_project1_ref))
+  expect_equal(names(tags_all), names(tags_all_ref))
+  expect_equal(names(tags_all), names(tags_tag1))
+  expect_equal(names(tags_all), names(tags_tag_multiple))
+})
 
-  # Number of records
-  expect_gte(nrow(tags_all), nrow(tags_project1))
-  expect_gte(nrow(tags_all), nrow(tags_projects_multiple))
-  expect_gte(nrow(tags_projects_multiple), nrow(tags_project1))
-  expect_gte(nrow(tags_project1_ref), nrow(tags_project1))
+testthat::test_that("Test number of records", {
+  expect_gt(nrow(tags_all_ref), nrow(tags_all))
+  expect_equal(nrow(tags_tag1), 2)
+  expect_equal(nrow(tags_tag_multiple), 2)
+})
 
-  # Selected parameter can be found in data
+testthat::test_that("Test if data is filtered on paramater", {
   expect_equal(
-    tags_project1 %>% distinct(type) %>% arrange() %>% pull(),
-    c("animal", "sentinel")
+    tags_tag1 %>% distinct(tag_id) %>% pull(),
+    c("A69-1303-65313")
   )
+  expect_equal(
+    tags_tag_multiple %>% distinct(tag_id) %>% arrange(tag_id) %>% pull(),
+    c("A69-1601-1705", "A69-1601-1707")
+  )
+})
 
-  # Unique IDs
-  # expect_equal(nrow(tags_all), nrow(tags_all %>% distinct(pk)))
-  # expect_equal(nrow(tags_all), nrow(tags_all %>% distinct(tag_id)))
+testthat::test_that("Test unique ids", {
+  expect_equal(nrow(tags_all), nrow(tags_all %>% distinct(pk)))
+  # expect_equal(nrow(tags_all), nrow(tags_all %>% distinct(tag_id))) # This is not the case
 })

--- a/tests/testthat/test-get_tags.R
+++ b/tests/testthat/test-get_tags.R
@@ -53,48 +53,65 @@ expected_col_names_tags <- c(
 )
 
 tags_all <- get_tags(con)
-tags_project1 <- get_tags(con, animal_project_code = "phd_reubens")
-tags_projects_multiple <- get_tags(con, animal_project_code = c(
-  "phd_reubens",
-  "2012_leopoldkanaal"
-))
-tags_project1_ref <- get_tags(con,
+tags_project1 <- get_tags(
+  con,
+  animal_project_code = "phd_reubens"
+)
+tags_projects_multiple <- get_tags(
+  con,
+  animal_project_code = c("phd_reubens", "2012_leopoldkanaal")
+)
+tags_project1_ref <- get_tags(
+  con,
   animal_project_code = "phd_reubens",
   include_reference_tags = TRUE
 )
 
 testthat::test_that("test_input_get_tags", {
-  expect_error(
-    get_tags("I am not a connection"),
+  expect_error(get_tags("I am not a connection"),
     "Not a connection object to database."
   )
-  expect_error(get_tags(con, animal_project_code = "very_bad_project"))
-  expect_error(get_tags(con, animal_project_code = c(
-    "phd_reubens",
-    "very_bad_project"
-  )))
-  expect_error(get_tags(con, include_reference_tags = "not logical"))
+  expect_error(get_tags(
+    con,
+    animal_project_code = "very_bad_project"
+  ))
+  expect_error(get_tags(
+    con,
+    animal_project_code = c("phd_reubens", "very_bad_project")
+  ))
+  expect_error(get_tags(
+    con,
+    include_reference_tags = "not logical"
+  ))
 })
 
 testthat::test_that("test_output_get_tags", {
-  library(dplyr)
+  # Output type
   expect_is(tags_all, "data.frame")
   expect_is(tags_project1, "data.frame")
   expect_is(tags_projects_multiple, "data.frame")
   expect_is(tags_project1_ref, "data.frame")
+
+  # Col names
   expect_true(all(names(tags_all) %in% expected_col_names_tags))
   expect_true(all(expected_col_names_tags %in% names(tags_all)))
+  expect_equal(names(tags_all), names(tags_project1))
+  expect_equal(names(tags_all), names(tags_projects_multiple))
+  expect_equal(names(tags_all), names(tags_project1_ref))
+
+  # Number of records
   expect_gte(nrow(tags_all), nrow(tags_project1))
   expect_gte(nrow(tags_all), nrow(tags_projects_multiple))
   expect_gte(nrow(tags_projects_multiple), nrow(tags_project1))
   expect_gte(nrow(tags_project1_ref), nrow(tags_project1))
-  expect_equal(names(tags_all), names(tags_project1))
-  expect_equal(names(tags_all), names(tags_projects_multiple))
-  expect_equal(names(tags_all), names(tags_project1_ref))
+
+  # Selected parameter can be found in data
   expect_equal(
     tags_project1 %>% distinct(type) %>% arrange() %>% pull(),
     c("animal", "sentinel")
   )
+
+  # Unique IDs
   # expect_equal(nrow(tags_all), nrow(tags_all %>% distinct(pk)))
   # expect_equal(nrow(tags_all), nrow(tags_all %>% distinct(tag_id)))
 })

--- a/tests/testthat/test-list_animal_project_codes.R
+++ b/tests/testthat/test-list_animal_project_codes.R
@@ -3,7 +3,7 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
-testthat::test_that("check_list_animal_project_codes", {
+testthat::test_that("Test output", {
   expect_is(list_animal_project_codes(con), "character")
   expect_false(any(duplicated(list_animal_project_codes(con))))
   expect_true("phd_reubens" %in% list_animal_project_codes(con))

--- a/tests/testthat/test-list_network_project_codes.R
+++ b/tests/testthat/test-list_network_project_codes.R
@@ -3,7 +3,7 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
-testthat::test_that("check_list_network_project_codes", {
+testthat::test_that("Test output", {
   expect_is(list_network_project_codes(con), "character")
   expect_false(any(duplicated(list_network_project_codes(con))))
   expect_true("thornton" %in% list_network_project_codes(con))

--- a/tests/testthat/test-list_receiver_ids.R
+++ b/tests/testthat/test-list_receiver_ids.R
@@ -3,7 +3,7 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
-testthat::test_that("check_list_receiver_ids", {
+testthat::test_that("Test output", {
   expect_is(list_receiver_ids(con), "character")
   expect_false(any(duplicated(list_receiver_ids(con))))
   expect_true("VR2W-122360" %in% list_receiver_ids(con))

--- a/tests/testthat/test-list_scientific_names.R
+++ b/tests/testthat/test-list_scientific_names.R
@@ -3,7 +3,7 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
-testthat::test_that("check_list_scientific_names", {
+testthat::test_that("Test output", {
   expect_is(list_scientific_names(con), "character")
   expect_false(any(duplicated(list_scientific_names(con))))
   expect_true("Anguilla anguilla" %in% list_scientific_names(con))

--- a/tests/testthat/test-list_station_names.R
+++ b/tests/testthat/test-list_station_names.R
@@ -3,7 +3,7 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
-testthat::test_that("check_list_station_names", {
+testthat::test_that("Test output", {
   expect_is(list_station_names(con), "character")
   expect_false(any(duplicated(list_station_names(con))))
   expect_true("R03" %in% list_station_names(con))

--- a/tests/testthat/test-list_tag_ids.R
+++ b/tests/testthat/test-list_tag_ids.R
@@ -3,7 +3,7 @@ con <- connect_to_etn(
   password = Sys.getenv("pwd")
 )
 
-testthat::test_that("check_list_tag_ids", {
+testthat::test_that("Test output", {
   expect_is(list_tag_ids(con), "character")
   expect_false(any(duplicated(list_tag_ids(con))))
   expect_true("A69-1303-65302" %in% list_tag_ids(con))

--- a/vignettes/etn.Rmd
+++ b/vignettes/etn.Rmd
@@ -38,8 +38,7 @@ devtools::install_github("inbo/etn")
 In order to access the data, the first step is always to connect with your user credentials (as received by VLIZ) to the database. 
 
 ```{r}
-my_con <- connect_to_etn(Sys.getenv("userid"),
-                         Sys.getenv("pwd"))
+con <- connect_to_etn(Sys.getenv("userid"), Sys.getenv("pwd"))
 ```
 
 Remark that for this example, we [load the user credentials as environmental variables](http://db.rstudio.com/best-practices/managing-credentials/#use-environment-variables) by saving an `.Renviron` file in the home directory with the username and password stored. Other options are available as well, as explained [here](http://db.rstudio.com/best-practices/managing-credentials/).
@@ -55,14 +54,14 @@ Notice, that you can find the `get_*`-functions inside Rstudio by typing: `etn::
 To get a full overview of the projects you have access to, use the function `get_projects()`:
 
 ```{r projects}
-my_projects <- get_projects(my_con)
+my_projects <- get_projects(con)
 head(my_projects, 10) # print 10 first
 ```
 
 As projects are defined both on the level of the `animal` as well as the `network`, a column `type` is available that defines the type of project (`animal` or `network`). Still, one can also directly subset by adding the type as input argument, e.g. for network:
 
 ```{r my_animal_projects}
-my_network_projects <- get_projects(my_con, project_type = "network")
+my_network_projects <- get_projects(con, project_type = "network")
 head(my_network_projects, 10) # print 10 first
 ```
 
@@ -71,14 +70,14 @@ head(my_network_projects, 10) # print 10 first
 A network project typically considers multiple receivers that are placed on specific locations to lay out the network. To get an overview of receivers deployments linked to specific projects, use the `get_deployments` function:
 
 ```{r}
-ws3_deployments <- get_deployments(my_con, network_project_code = "ws3")
+ws3_deployments <- get_deployments(con, network_project_code = "ws3")
 head(ws3_deployments, 10) # print 10 first
 ```
 
 You can also define multiple (network) projects at the same time, by combining them in a vector:
 
 ```{r}
-ws_deployments <- get_deployments(my_con, network_project_code = c("ws1", "ws3"))
+ws_deployments <- get_deployments(con, network_project_code = c("ws1", "ws3"))
 head(ws_deployments, 10) # print 10 first
 ```
 
@@ -101,7 +100,7 @@ ws_deployments %>%
 Receivers are deployed for a specific period and this deployment information can be accessed as well with the command `get_deployments`. Filtering on the network project is similar to `get_receivers` and as the information about the receiver `status` is crucial, the function provides an additional argument to query based on the receiver status. Getting an overview of the lost and broken receivers of a specific project:
 
 ```{r}
-my_deployments <- get_deployments(my_con, network_project_code = "ws1", 
+my_deployments <- get_deployments(con, network_project_code = "ws1", 
                                   receiver_status = c("Broken", "Lost"))
 head(my_deployments, 10) # print 10 first 
 ```
@@ -113,14 +112,14 @@ Within an animal project, multiple animals are provided with a transmitter. The 
 As such, selecting the animals metadata for the `2012_leopoldkanaal` project:
 
 ```{r}
-my_animals <- get_animals(my_con, animal_project_code = "2012_leopoldkanaal")
+my_animals <- get_animals(con, animal_project_code = "2012_leopoldkanaal")
 head(my_animals, 10) # print 10 first
 ```
 
 When interested in specific species, add the scientific name as argument.
 
 ```{r}
-my_animals <- get_animals(my_con, animal_project_code = "phd_reubens",
+my_animals <- get_animals(con, animal_project_code = "phd_reubens",
                        scientific_name = "Sentinel")
 head(my_animals, 10) # print 10 first
 ```
@@ -132,7 +131,7 @@ Remark: currently these names are NOT yet verified with a taxonomic backbone as 
 The transmitters/tags metadata can be accessed by the `get_tags` function, with the option to subset on the animal project names:
 
 ```{r}
-my_tags <- get_tags(my_con, animal_project_code = "phd_reubens")
+my_tags <- get_tags(con, animal_project_code = "phd_reubens")
 head(my_tags, 10) # print 10 first
 ```
 
@@ -143,7 +142,7 @@ The raw detections are the core for any type of analysis and access is provided 
 To narrow down the data request, filters are provided on animal/network project name, the deployment station name and the transmitter identifier to narrow. Furthermore, as these data sets can be large, some additional time-based filters are provided with a `start_date` and an `end_date`: 
 
 ```{r}
-my_detections <- get_detections(my_con, animal_project_code = "phd_reubens", 
+my_detections <- get_detections(con, animal_project_code = "phd_reubens", 
                                 start_date = "2011-01-28", end_date = "2011-02-01")
 head(my_detections, 10) # print 10 first
 ```

--- a/vignettes/etn.Rmd
+++ b/vignettes/etn.Rmd
@@ -128,17 +128,16 @@ Remark: currently these names are NOT yet verified with a taxonomic backbone as 
 
 ### Transmitter overview
 
-The transmitters/tags metadata can be accessed by the `get_tags` function, with the option to subset on the animal project names:
+The transmitters/tags metadata can be accessed by the `get_tags` function:
 
 ```{r}
-my_tags <- get_tags(con, animal_project_code = "phd_reubens")
+my_tags <- get_tags(con)
 head(my_tags, 10) # print 10 first
 ```
 
 ## Detections data
 
 The raw detections are the core for any type of analysis and access is provided by the `get_detections` function. Different filters are available which you can explore by typing `?get_detections` in the console. 
-
 To narrow down the data request, filters are provided on animal/network project name, the deployment station name and the transmitter identifier to narrow. Furthermore, as these data sets can be large, some additional time-based filters are provided with a `start_date` and an `end_date`: 
 
 ```{r}


### PR DESCRIPTION
- Use default con (will result in NOTE) fix #99
- Limit detections by default and use `TRUE/FALSE` as parameter fix #98 
- `get_tags()` update parameters: drop network code + add tag_id fix #95 
- `get_receivers()` update parameters: drop animal code + add receiver_id fix #94
- Structure tests
- Bump version to 9101