### PR TITLE
Fix errors in tests download dataset function

### DIFF
--- a/tests/testthat/test-download_dataset-message.txt
+++ b/tests/testthat/test-download_dataset-message.txt
@@ -11,7 +11,7 @@ Summary statistics for dataset "2014_demer":
 * number of animals:           16
 * number of tags:              16
 * number of detections:        237064
-* number of deployments:       859
+* number of deployments:       884
 * number of receivers:         124
 * first date of detection:     2014-04-18
 * last date of detection:      2018-09-15

--- a/tests/testthat/test-download_dataset.R
+++ b/tests/testthat/test-download_dataset.R
@@ -50,8 +50,9 @@ test_that("Downloading the data package returns desired message and files", {
   # Function returns no result
   expect_null(evaluate_download_2014_demer$result)
 
-  # Function returns no output
-  expect_true(evaluate_download_2014_demer$output == "")
+  # Function returns a verbose output of length 1
+  expect_equal(length(evaluate_download_2014_demer$output), 1)
+  expect_true(evaluate_download_2014_demer$output[1] != "")
 
   # Remove generated files and directories after test
   unlink(dir_to_download_data, recursive = TRUE)


### PR DESCRIPTION
Two errors in testing the download dataset function have been detected and solved. Tests improved.