### PR TITLE
Hotfix `write_dwc` failing sql parsing + support uppercase

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etn
 Title: Access Data from the European Tracking Network
-Version: 2.2.0
+Version: 2.2.1
 Authors@R: c(
     person("Pieter", "Huybrechts", email = "pieter.huybrechts@inbo.be",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6658-6062")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # etn 2.2.1
 
 * Fix bug in `write_dwc()` where the function would return an error due to an updated dependency (#293).
-- Added support for UPPERCASE `animal_project_code`'s in `write_dwc()` #289
+* Add support for UPPERCASE `animal_project_code`s in `write_dwc()` (#289).
 
 # etn 2.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# etn 2.2.1
+
 # etn 2.2.0
 
 * Add `NEWS.md` file to communicate changes to the package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # etn 2.2.1
 
+- Fix bug in `write_dwc()` bug where the function would return an error due to an updated dependency. #293
+- Added support for UPPERCASE `animal_project_code`'s in `write_dwc()` #289
+
 # etn 2.2.0
 
 * Add `NEWS.md` file to communicate changes to the package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # etn 2.2.1
 
-- Fix bug in `write_dwc()` bug where the function would return an error due to an updated dependency. #293
+* Fix bug in `write_dwc()` where the function would return an error due to an updated dependency (#293).
 - Added support for UPPERCASE `animal_project_code`'s in `write_dwc()` #289
 
 # etn 2.2.0

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -56,6 +56,8 @@ write_dwc <- function(connection = con,
     length(animal_project_code) == 1,
     msg = "`animal_project_code` must be a single value."
   )
+  ## Set animal project code to lowercase for sql
+  animal_project_code <- stringr::str_to_lower(animal_project_code)
 
   # Check license
   licenses <- c("CC-BY", "CC0")

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -84,7 +84,8 @@ write_dwc <- function(connection = con,
   message("Reading data and transforming to Darwin Core.")
   dwc_occurrence_sql <- glue::glue_sql(
     readr::read_file(system.file("sql/dwc_occurrence.sql", package = "etn")),
-    .con = connection
+    .con = connection,
+    .null = "NULL"
   )
   dwc_occurrence <- DBI::dbGetQuery(connection, dwc_occurrence_sql)
 

--- a/tests/testthat/_snaps/download_acoustic_dataset.md
+++ b/tests/testthat/_snaps/download_acoustic_dataset.md
@@ -15,8 +15,8 @@
       * number of animals:           16
       * number of tags:              16
       * number of detections:        236918
-      * number of deployments:       1081
-      * number of receivers:         244
+      * number of deployments:       1122
+      * number of receivers:         255
       * first date of detection:     2014-04-18
       * last date of detection:      2018-09-15
       * included scientific names:   Petromyzon marinus, Rutilus rutilus, Silurus glanis, Squalius cephalus

--- a/tests/testthat/test-write_dwc.R
+++ b/tests/testthat/test-write_dwc.R
@@ -63,3 +63,13 @@ test_that("write_dwc() returns the expected Darwin Core terms as columns", {
     )
   )
 })
+
+test_that("write_dwc() supports uppercase animal_project_code's", {
+  result <- suppressMessages(
+    write_dwc(con, animal_project_code = "2011_RIVIERPRIK", directory = NULL)
+  )
+
+  expect_identical(names(result), "dwc_occurrence")
+  expect_s3_class(result$dwc_occurrence, "tbl")
+  expect_gte(length(result$dwc_occurrence$occurrenceID), 1)
+})

--- a/tests/testthat/test-write_dwc.R
+++ b/tests/testthat/test-write_dwc.R
@@ -64,7 +64,7 @@ test_that("write_dwc() returns the expected Darwin Core terms as columns", {
   )
 })
 
-test_that("write_dwc() supports uppercase animal_project_code's", {
+test_that("write_dwc() supports uppercase animal_project_codes", {
   result <- suppressMessages(
     write_dwc(con, animal_project_code = "2011_RIVIERPRIK", directory = NULL)
   )


### PR DESCRIPTION
- Set extra parameter to ensure passing `NULL` to glue is passed as `"NULL"` strings to the database, instead of the whole query being dropped. 

- Updated a snapshot, because the database has changed since the last unit test check. 

- Convert `animal_project_code` to lowercase for SQL injection in `write_dwc()`: fixes #289 : bff9852f

---

Since glue v1.7.0 a literal NULL will result in the line (in this case, the whole file) being dropped. Before it was returned as "NULL" by default. This change set's it to it's old default behaviour.

In principle this bug would have been present as soon as someone updated glue as of the 10th of January this year. 