### PR TITLE
Fix LifeWatch logo link

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -15,7 +15,7 @@ authors:
     href: https://twitter.com/SVanHoey
   LifeWatch Belgium:
     href: https://lifewatch.be
-    html: "<img src='https://www.lifewatch.be/sites/lifewatch.be/themes/lifewatchportal/images/header_lw_logo.png' width=72>"
+    html: "<img src='https://oscibio.inbo.be/assets/logos/lifewatch-belgium.svg' width=72>"
 
 home:
   links:


### PR DESCRIPTION
Broke with release of new website