### PR TITLE
Update examples to use API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,6 @@ Imports:
     lubridate,
     methods,
     odbc,
-    purrr,
     readr,
     rlang,
     stringr

--- a/R/download_acoustic_dataset.R
+++ b/R/download_acoustic_dataset.R
@@ -48,9 +48,6 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Set default connection variable
-#' con <- connect_to_etn()
-#'
 #' # Download data for the 2012_leopoldkanaal animal project (all scientific names)
 #' download_acoustic_dataset(animal_project_code = "2012_leopoldkanaal")
 #' #> Downloading data to directory `2012_leopoldkanaal`:

--- a/R/get_acoustic_deployments.R
+++ b/R/get_acoustic_deployments.R
@@ -20,26 +20,23 @@
 #' @export
 #'
 #' @examples
-#' # Set default connection variable
-#' con <- connect_to_etn()
-#'
 #' # Get all acoustic deployments
-#' get_acoustic_deployments(con)
+#' get_acoustic_deployments()
 #'
 #' # Get specific acoustic deployment
-#' get_acoustic_deployments(con, deployment_id = 1437)
+#' get_acoustic_deployments(deployment_id = 1437)
 #'
 #' # Get acoustic deployments for a specific receiver
-#' get_acoustic_deployments(con, receiver_id = "VR2W-124070")
+#' get_acoustic_deployments(receiver_id = "VR2W-124070")
 #'
 #' # Get open acoustic deployments for a specific receiver
-#' get_acoustic_deployments(con, receiver_id = "VR2W-124070", open_only = TRUE)
+#' get_acoustic_deployments(receiver_id = "VR2W-124070", open_only = TRUE)
 #'
 #' # Get acoustic deployments for a specific acoustic project
-#' get_acoustic_deployments(con, acoustic_project_code = "demer")
+#' get_acoustic_deployments(acoustic_project_code = "demer")
 #'
 #' # Get acoustic deployments for two specific stations
-#' get_acoustic_deployments(con, station_name = c("de-9", "de-10"))
+#' get_acoustic_deployments(station_name = c("de-9", "de-10"))
 get_acoustic_deployments <- function(connection,
                                      deployment_id = NULL,
                                      receiver_id = NULL,

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -28,18 +28,14 @@
 #' @export
 #'
 #' @examples
-#' # Set default connection variable
-#' con <- connect_to_etn()
-#'
 #' # Get limited sample of acoustic detections
-#' get_acoustic_detections(con, limit = TRUE)
+#' get_acoustic_detections(limit = TRUE)
 #'
 #' # Get all acoustic detections from a specific animal project
-#' get_acoustic_detections(con, animal_project_code = "2014_demer")
+#' get_acoustic_detections(animal_project_code = "2014_demer")
 #'
 #' # Get 2015 acoustic detections from that animal project
 #' get_acoustic_detections(
-#'   con,
 #'   animal_project_code = "2014_demer",
 #'   start_date = "2015",
 #'   end_date = "2016",
@@ -47,7 +43,6 @@
 #'
 #' # Get April 2015 acoustic detections from that animal project
 #' get_acoustic_detections(
-#'   con,
 #'   animal_project_code = "2014_demer",
 #'   start_date = "2015-04",
 #'   end_date = "2015-05",
@@ -55,7 +50,6 @@
 #'
 #' # Get April 24, 2015 acoustic detections from that animal project
 #' get_acoustic_detections(
-#'   con,
 #'   animal_project_code = "2014_demer",
 #'   start_date = "2015-04-24",
 #'   end_date = "2015-04-25",
@@ -63,14 +57,12 @@
 #'
 #' # Get acoustic detections for a specific tag at two specific stations
 #' get_acoustic_detections(
-#'   con,
 #'   acoustic_tag_id = "A69-1601-16130",
 #'   station_name = c("de-9", "de-10")
 #' )
 #'
 #' # Get acoustic detections for a specific species, receiver and acoustic project
 #' get_acoustic_detections(
-#'   con,
 #'   scientific_name = "Rutilus rutilus",
 #'   receiver_id = "VR2W-124070",
 #'   acoustic_project_code = "demer"

--- a/R/get_acoustic_projects.R
+++ b/R/get_acoustic_projects.R
@@ -13,14 +13,11 @@
 #' @export
 #'
 #' @examples
-#' # Set default connection variable
-#' con <- connect_to_etn()
-#'
 #' # Get all acoustic projects
-#' get_acoustic_projects(con)
+#' get_acoustic_projects()
 #'
 #' # Get a specific acoustic project
-#' get_acoustic_projects(con, acoustic_project_code = "demer")
+#' get_acoustic_projects(acoustic_project_code = "demer")
 get_acoustic_projects <- function(connection,
                                   acoustic_project_code = NULL,
                                   api = TRUE){

--- a/R/get_acoustic_receivers.R
+++ b/R/get_acoustic_receivers.R
@@ -15,17 +15,14 @@
 #' @export
 #'
 #' @examples
-#' # Set default connection variable
-#' con <- connect_to_etn()
-#'
 #' # Get all acoustic receivers
-#' get_acoustic_receivers(con)
+#' get_acoustic_receivers()
 #'
 #' # Get lost and broken acoustic receivers
-#' get_acoustic_receivers(con, status = c("lost", "broken"))
+#' get_acoustic_receivers(status = c("lost", "broken"))
 #'
 #' # Get a specific acoustic receiver
-#' get_acoustic_receivers(con, receiver_id = "VR2W-124070")
+#' get_acoustic_receivers(receiver_id = "VR2W-124070")
 get_acoustic_receivers <- function(connection,
                                    receiver_id = NULL,
                                    status = NULL,

--- a/R/get_animal_projects.R
+++ b/R/get_animal_projects.R
@@ -13,14 +13,11 @@
 #' @export
 #'
 #' @examples
-#' # Set default connection variable
-#' con <- connect_to_etn()
-#'
 #' # Get all animal projects
-#' get_animal_projects(con)
+#' get_animal_projects()
 #'
 #' # Get a specific animal project
-#' get_animal_projects(con, animal_project_code = "2014_demer")
+#' get_animal_projects(animal_project_code = "2014_demer")
 get_animal_projects <- function(connection,
                                 animal_project_code = NULL,
                                 api = TRUE){

--- a/R/get_animals.R
+++ b/R/get_animals.R
@@ -19,28 +19,25 @@
 #' @export
 #'
 #' @examples
-#' # Set default connection variable
-#' con <- connect_to_etn()
-#'
 #' # Get all animals
-#' get_animals(con)
+#' get_animals()
 #'
 #' # Get specific animals
-#' get_animals(con, animal_id = 305) # Or string value "305"
-#' get_animals(con, animal_id = c(304, 305, 2827))
+#' get_animals(animal_id = 305) # Or string value "305"
+#' get_animals(animal_id = c(304, 305, 2827))
 #'
 #' # Get animals from specific animal project(s)
-#' get_animals(con, animal_project_code = "2014_demer")
-#' get_animals(con, animal_project_code = c("2014_demer", "2015_dijle"))
+#' get_animals(animal_project_code = "2014_demer")
+#' get_animals(animal_project_code = c("2014_demer", "2015_dijle"))
 #'
 #' # Get animals associated with a specific tag_serial_number
-#' get_animals(con, tag_serial_number = "1187450")
+#' get_animals(tag_serial_number = "1187450")
 #'
 #' # Get animals of specific species (across all projects)
-#' get_animals(con, scientific_name = c("Rutilus rutilus", "Silurus glanis"))
+#' get_animals(scientific_name = c("Rutilus rutilus", "Silurus glanis"))
 #'
 #' # Get animals of a specific species from a specific project
-#' get_animals(con, animal_project_code = "2014_demer", scientific_name = "Rutilus rutilus")
+#' get_animals(animal_project_code = "2014_demer", scientific_name = "Rutilus rutilus")
 get_animals <- function(connection,
                         animal_id = NULL,
                         tag_serial_number = NULL,

--- a/R/get_cpod_projects.R
+++ b/R/get_cpod_projects.R
@@ -13,14 +13,11 @@
 #' @export
 #'
 #' @examples
-#' # Set default connection variable
-#' con <- connect_to_etn()
-#'
 #' # Get all animal projects
-#' get_cpod_projects(con)
+#' get_cpod_projects()
 #'
 #' # Get a specific animal project
-#' get_cpod_projects(con, cpod_project_code = "cpod-lifewatch")
+#' get_cpod_projects(cpod_project_code = "cpod-lifewatch")
 get_cpod_projects <- function(connection,
                               cpod_project_code = NULL,
                               api = TRUE) {

--- a/R/get_tags.R
+++ b/R/get_tags.R
@@ -21,22 +21,19 @@
 #' @export
 #'
 #' @examples
-#' # Set default connection variable
-#' con <- connect_to_etn()
-#'
 #' # Get all tags
-#' get_tags(con)
+#' get_tags()
 #'
 #' # Get archival tags, including acoustic-archival
-#' get_tags(con, tag_type = c("archival", "acoustic-archival"))
+#' get_tags(tag_type = c("archival", "acoustic-archival"))
 #'
 #' # Get tags of specific subtype
-#' get_tags(con, tag_subtype = c("built-in", "range"))
+#' get_tags(tag_subtype = c("built-in", "range"))
 #'
 #' # Get specific tags (note that these can return multiple records)
-#' get_tags(con, tag_serial_number = "1187450")
-#' get_tags(con, acoustic_tag_id = "A69-1601-16130")
-#' get_tags(con, acoustic_tag_id = c("A69-1601-16129", "A69-1601-16130"))
+#' get_tags(tag_serial_number = "1187450")
+#' get_tags(acoustic_tag_id = "A69-1601-16130")
+#' get_tags(acoustic_tag_id = c("A69-1601-16129", "A69-1601-16130"))
 get_tags <- function(connection,
                      tag_type = NULL,
                      tag_subtype = NULL,

--- a/R/list_values.R
+++ b/R/list_values.R
@@ -16,12 +16,10 @@
 #' @export
 #'
 #' @examples
-#' # Set default connection variable
-#' con <- connect_to_etn()
 #' library(dplyr) # For %>%
 #'
 #' # List unique scientific_name from a dataframe containing animal information
-#' df <- get_animals(con, animal_project_code = "2014_demer")
+#' df <- get_animals(animal_project_code = "2014_demer")
 #' list_values(df, "scientific_name")
 #'
 #' # Or using pipe and unquoted column name
@@ -31,7 +29,7 @@
 #' df %>% list_values(8)
 #'
 #' # tag_serial_number can contain comma-separated values
-#' df <- get_animals(con, animal_id = 5841)
+#' df <- get_animals(animal_id = 5841)
 #' df$tag_serial_number
 #'
 #' # list_values() will split those and return unique values

--- a/man/download_acoustic_dataset.Rd
+++ b/man/download_acoustic_dataset.Rd
@@ -69,9 +69,6 @@ performed by validation tools of the Frictionless Framework, e.g.
 }
 \examples{
 \dontrun{
-# Set default connection variable
-con <- connect_to_etn()
-
 # Download data for the 2012_leopoldkanaal animal project (all scientific names)
 download_acoustic_dataset(animal_project_code = "2012_leopoldkanaal")
 #> Downloading data to directory `2012_leopoldkanaal`:

--- a/man/get_acoustic_deployments.Rd
+++ b/man/get_acoustic_deployments.Rd
@@ -44,24 +44,21 @@ Get data for deployments of acoustic receivers, with options to filter
 results.
 }
 \examples{
-# Set default connection variable
-con <- connect_to_etn()
-
 # Get all acoustic deployments
-get_acoustic_deployments(con)
+get_acoustic_deployments()
 
 # Get specific acoustic deployment
-get_acoustic_deployments(con, deployment_id = 1437)
+get_acoustic_deployments(deployment_id = 1437)
 
 # Get acoustic deployments for a specific receiver
-get_acoustic_deployments(con, receiver_id = "VR2W-124070")
+get_acoustic_deployments(receiver_id = "VR2W-124070")
 
 # Get open acoustic deployments for a specific receiver
-get_acoustic_deployments(con, receiver_id = "VR2W-124070", open_only = TRUE)
+get_acoustic_deployments(receiver_id = "VR2W-124070", open_only = TRUE)
 
 # Get acoustic deployments for a specific acoustic project
-get_acoustic_deployments(con, acoustic_project_code = "demer")
+get_acoustic_deployments(acoustic_project_code = "demer")
 
 # Get acoustic deployments for two specific stations
-get_acoustic_deployments(con, station_name = c("de-9", "de-10"))
+get_acoustic_deployments(station_name = c("de-9", "de-10"))
 }

--- a/man/get_acoustic_detections.Rd
+++ b/man/get_acoustic_detections.Rd
@@ -59,18 +59,14 @@ Get data for acoustic detections, with options to filter results. Use
 \code{limit} to limit the number of returned records.
 }
 \examples{
-# Set default connection variable
-con <- connect_to_etn()
-
 # Get limited sample of acoustic detections
-get_acoustic_detections(con, limit = TRUE)
+get_acoustic_detections(limit = TRUE)
 
 # Get all acoustic detections from a specific animal project
-get_acoustic_detections(con, animal_project_code = "2014_demer")
+get_acoustic_detections(animal_project_code = "2014_demer")
 
 # Get 2015 acoustic detections from that animal project
 get_acoustic_detections(
-  con,
   animal_project_code = "2014_demer",
   start_date = "2015",
   end_date = "2016",
@@ -78,7 +74,6 @@ get_acoustic_detections(
 
 # Get April 2015 acoustic detections from that animal project
 get_acoustic_detections(
-  con,
   animal_project_code = "2014_demer",
   start_date = "2015-04",
   end_date = "2015-05",
@@ -86,7 +81,6 @@ get_acoustic_detections(
 
 # Get April 24, 2015 acoustic detections from that animal project
 get_acoustic_detections(
-  con,
   animal_project_code = "2014_demer",
   start_date = "2015-04-24",
   end_date = "2015-04-25",
@@ -94,14 +88,12 @@ get_acoustic_detections(
 
 # Get acoustic detections for a specific tag at two specific stations
 get_acoustic_detections(
-  con,
   acoustic_tag_id = "A69-1601-16130",
   station_name = c("de-9", "de-10")
 )
 
 # Get acoustic detections for a specific species, receiver and acoustic project
 get_acoustic_detections(
-  con,
   scientific_name = "Rutilus rutilus",
   receiver_id = "VR2W-124070",
   acoustic_project_code = "demer"

--- a/man/get_acoustic_projects.Rd
+++ b/man/get_acoustic_projects.Rd
@@ -25,12 +25,9 @@ also
 Get data for acoustic projects, with options to filter results.
 }
 \examples{
-# Set default connection variable
-con <- connect_to_etn()
-
 # Get all acoustic projects
-get_acoustic_projects(con)
+get_acoustic_projects()
 
 # Get a specific acoustic project
-get_acoustic_projects(con, acoustic_project_code = "demer")
+get_acoustic_projects(acoustic_project_code = "demer")
 }

--- a/man/get_acoustic_receivers.Rd
+++ b/man/get_acoustic_receivers.Rd
@@ -33,15 +33,12 @@ the group.
 Get data for acoustic receivers, with options to filter results.
 }
 \examples{
-# Set default connection variable
-con <- connect_to_etn()
-
 # Get all acoustic receivers
-get_acoustic_receivers(con)
+get_acoustic_receivers()
 
 # Get lost and broken acoustic receivers
-get_acoustic_receivers(con, status = c("lost", "broken"))
+get_acoustic_receivers(status = c("lost", "broken"))
 
 # Get a specific acoustic receiver
-get_acoustic_receivers(con, receiver_id = "VR2W-124070")
+get_acoustic_receivers(receiver_id = "VR2W-124070")
 }

--- a/man/get_animal_projects.Rd
+++ b/man/get_animal_projects.Rd
@@ -25,12 +25,9 @@ also
 Get data for animal projects, with options to filter results.
 }
 \examples{
-# Set default connection variable
-con <- connect_to_etn()
-
 # Get all animal projects
-get_animal_projects(con)
+get_animal_projects()
 
 # Get a specific animal project
-get_animal_projects(con, animal_project_code = "2014_demer")
+get_animal_projects(animal_project_code = "2014_demer")
 }

--- a/man/get_animals.Rd
+++ b/man/get_animals.Rd
@@ -41,26 +41,23 @@ information is available in columns starting with \code{tag} and
 the information is comma-separated.
 }
 \examples{
-# Set default connection variable
-con <- connect_to_etn()
-
 # Get all animals
-get_animals(con)
+get_animals()
 
 # Get specific animals
-get_animals(con, animal_id = 305) # Or string value "305"
-get_animals(con, animal_id = c(304, 305, 2827))
+get_animals(animal_id = 305) # Or string value "305"
+get_animals(animal_id = c(304, 305, 2827))
 
 # Get animals from specific animal project(s)
-get_animals(con, animal_project_code = "2014_demer")
-get_animals(con, animal_project_code = c("2014_demer", "2015_dijle"))
+get_animals(animal_project_code = "2014_demer")
+get_animals(animal_project_code = c("2014_demer", "2015_dijle"))
 
 # Get animals associated with a specific tag_serial_number
-get_animals(con, tag_serial_number = "1187450")
+get_animals(tag_serial_number = "1187450")
 
 # Get animals of specific species (across all projects)
-get_animals(con, scientific_name = c("Rutilus rutilus", "Silurus glanis"))
+get_animals(scientific_name = c("Rutilus rutilus", "Silurus glanis"))
 
 # Get animals of a specific species from a specific project
-get_animals(con, animal_project_code = "2014_demer", scientific_name = "Rutilus rutilus")
+get_animals(animal_project_code = "2014_demer", scientific_name = "Rutilus rutilus")
 }

--- a/man/get_cpod_projects.Rd
+++ b/man/get_cpod_projects.Rd
@@ -25,12 +25,9 @@ also
 Get data for cpod projects, with options to filter results.
 }
 \examples{
-# Set default connection variable
-con <- connect_to_etn()
-
 # Get all animal projects
-get_cpod_projects(con)
+get_cpod_projects()
 
 # Get a specific animal project
-get_cpod_projects(con, cpod_project_code = "cpod-lifewatch")
+get_cpod_projects(cpod_project_code = "cpod-lifewatch")
 }

--- a/man/get_tags.Rd
+++ b/man/get_tags.Rd
@@ -43,20 +43,17 @@ can be multiple records (\code{acoustic_tag_id}) per tag device
 (\code{tag_serial_number}).
 }
 \examples{
-# Set default connection variable
-con <- connect_to_etn()
-
 # Get all tags
-get_tags(con)
+get_tags()
 
 # Get archival tags, including acoustic-archival
-get_tags(con, tag_type = c("archival", "acoustic-archival"))
+get_tags(tag_type = c("archival", "acoustic-archival"))
 
 # Get tags of specific subtype
-get_tags(con, tag_subtype = c("built-in", "range"))
+get_tags(tag_subtype = c("built-in", "range"))
 
 # Get specific tags (note that these can return multiple records)
-get_tags(con, tag_serial_number = "1187450")
-get_tags(con, acoustic_tag_id = "A69-1601-16130")
-get_tags(con, acoustic_tag_id = c("A69-1601-16129", "A69-1601-16130"))
+get_tags(tag_serial_number = "1187450")
+get_tags(acoustic_tag_id = "A69-1601-16130")
+get_tags(acoustic_tag_id = c("A69-1601-16129", "A69-1601-16130"))
 }

--- a/man/list_values.Rd
+++ b/man/list_values.Rd
@@ -25,12 +25,10 @@ Concatenated values (\verb{A,B}) in the column can be returned as single values
 (\code{A} and \code{B}).
 }
 \examples{
-# Set default connection variable
-con <- connect_to_etn()
 library(dplyr) # For \%>\%
 
 # List unique scientific_name from a dataframe containing animal information
-df <- get_animals(con, animal_project_code = "2014_demer")
+df <- get_animals(animal_project_code = "2014_demer")
 list_values(df, "scientific_name")
 
 # Or using pipe and unquoted column name
@@ -40,7 +38,7 @@ df \%>\% list_values(scientific_name)
 df \%>\% list_values(8)
 
 # tag_serial_number can contain comma-separated values
-df <- get_animals(con, animal_id = 5841)
+df <- get_animals(animal_id = 5841)
 df$tag_serial_number
 
 # list_values() will split those and return unique values


### PR DESCRIPTION
- remove `connect_to_etn()` and usage of `connection` argument from all function examples, this function is hard deprecated as of #313 
- Also drop `purrr` as a dependency, is unused. I only recently added it, and apparently refactored out the code where I used it. 

Note that R CMD CHECK will still fail as long as the changes from #313 are not merged and updated into this branch. You can check the package without vignettes by running: `devtools::check(vignette = FALSE)`