### PR TITLE
Refactor create connection

### DIFF
--- a/R/get_acoustic_deployments.R
+++ b/R/get_acoustic_deployments.R
@@ -68,7 +68,7 @@ get_acoustic_deployments_sql <- function(deployment_id = NULL,
                                          station_name = NULL,
                                          open_only = FALSE) {
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
 
   # Check connection
   check_connection(connection)

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -111,7 +111,7 @@ get_acoustic_detections_sql <- function(start_date = NULL,
                                     station_name = NULL,
                                     limit = FALSE) {
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/get_acoustic_projects.R
+++ b/R/get_acoustic_projects.R
@@ -40,7 +40,7 @@ get_acoustic_projects <- function(connection,
 #'
 get_acoustic_projects_sql <- function(acoustic_project_code = NULL) {
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/get_acoustic_receivers.R
+++ b/R/get_acoustic_receivers.R
@@ -43,7 +43,7 @@ get_acoustic_receivers <- function(connection,
 get_acoustic_receivers_sql <- function(receiver_id = NULL,
                                    status = NULL) {
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/get_animal_projects.R
+++ b/R/get_animal_projects.R
@@ -41,7 +41,7 @@ get_animal_projects <- function(connection,
 #'
 get_animal_projects_sql <- function(animal_project_code = NULL) {
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/get_animals.R
+++ b/R/get_animals.R
@@ -67,7 +67,7 @@ get_animals_sql <- function(animal_id = NULL,
                             animal_project_code = NULL,
                             scientific_name = NULL) {
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/get_cpod_projects.R
+++ b/R/get_cpod_projects.R
@@ -41,7 +41,7 @@ get_cpod_projects <- function(connection,
 #'
 get_cpod_projects_sql <- function(cpod_project_code = NULL) {
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/get_tags.R
+++ b/R/get_tags.R
@@ -62,7 +62,7 @@ get_tags_sql <- function(tag_type = NULL,
                          tag_serial_number = NULL,
                          acoustic_tag_id = NULL) {
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/list_acoustic_project_codes.R
+++ b/R/list_acoustic_project_codes.R
@@ -25,7 +25,7 @@ list_acoustic_project_codes <- function(connection,
 #'
 list_acoustic_project_codes_sql <- function(){
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
   project_sql <- glue::glue_sql(

--- a/R/list_acoustic_tag_ids.R
+++ b/R/list_acoustic_tag_ids.R
@@ -24,7 +24,7 @@ list_acoustic_tag_ids <- function(connection,
 #'
 list_acoustic_tag_ids_sql <- function(){
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/list_animal_ids.R
+++ b/R/list_animal_ids.R
@@ -27,7 +27,7 @@ list_animal_ids <- function(connection,
 #'
 list_animal_ids_sql <- function() {
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/list_animal_project_codes.R
+++ b/R/list_animal_project_codes.R
@@ -24,7 +24,7 @@ list_animal_project_codes <- function(connection,
 #'
 list_animal_project_codes_sql <- function(){
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/list_cpod_project_codes.R
+++ b/R/list_cpod_project_codes.R
@@ -24,7 +24,7 @@ list_cpod_project_codes <- function(connection, api = TRUE){
 list_cpod_project_codes_sql <- function() {
 
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/list_deployment_ids.R
+++ b/R/list_deployment_ids.R
@@ -22,7 +22,7 @@ list_deployment_ids <- function(connection, api = TRUE) {
 #'
 list_deployment_ids_sql <- function() {
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/list_receiver_ids.R
+++ b/R/list_receiver_ids.R
@@ -24,7 +24,7 @@ list_receiver_ids <- function(connection,
 #'
 list_receiver_ids_sql <- function(){
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/list_scientific_names.R
+++ b/R/list_scientific_names.R
@@ -23,7 +23,7 @@ list_scientific_names <- function(connection,
 #'
 list_scientific_names_sql <- function(){
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/list_station_names.R
+++ b/R/list_station_names.R
@@ -23,7 +23,7 @@ list_station_names <- function(connection,
 #'
 list_station_names_sql <- function(){
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/list_tag_serial_numbers.R
+++ b/R/list_tag_serial_numbers.R
@@ -24,7 +24,7 @@ list_tag_serial_numbers <- function(connection,
 #'
 list_tag_serial_numbers_sql <- function() {
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -391,21 +391,21 @@ conduct_parent_to_helpers <- function(api,
 #'
 #' @return ODBC connection to ETN database.
 #' @noRd
-create_connection <- function(username, password) {
+create_connection <- function(credentials = list(username, password)) {
   # Check the input arguments
   assertthat::assert_that(
-    assertthat::is.string(username)
+    assertthat::is.string(credentials$username)
   )
   assertthat::assert_that(
-    assertthat::is.string(password)
+    assertthat::is.string(credentials$password)
   )
 
   # Connect to the ETN database
   con <- DBI::dbConnect(
     odbc::odbc(),
     "ETN",
-    uid = tolower(username),
-    pwd = password
+    uid = tolower(credentials$username),
+    pwd = credentials$password
   )
   return(con)
 }

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -90,7 +90,7 @@ write_dwc_sql <- function(animal_project_code,
                           rights_holder = NULL,
                           license = "CC-BY") {
   # Create connection
-  connection <- do.call(create_connection, get_credentials())
+  connection <- create_connection(credentials = get_credentials())
   # Check connection
   check_connection(connection)
 


### PR DESCRIPTION
Quick refactoring to avoid `do.call` which I find harder to read as nested functions. Originally I needed do.call because I didn't want to touch connect_to_etn(), but since I have a new helper, I can of course change this behaviour and accept a list as an argument instead of separate values for username and password. 