### PR TITLE
Use Apache Feather for API object transfer instead of RDS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: etn
 Title: Access Data from the European Tracking Network
-Version: 2.3.0
+Version: 2.3.1.9000
 Authors@R: c(
     person("Peter", "Desmet", email = "peter.desmet@inbo.be",
            role = c("aut", "cre"), comment =  c(ORCID = "0000-0002-8442-8025")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ License: MIT + file LICENSE
 URL: https://github.com/inbo/etn, https://inbo.github.io/etn
 BugReports: https://github.com/inbo/etn/issues
 Depends:
-    R (>= 3.4.0)
+    R (>= 4.0)
 Imports:
     arrow,
     askpass,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
     lubridate,
     methods,
     odbc,
+    protolite,
     readr,
     rlang,
     stringr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ BugReports: https://github.com/inbo/etn/issues
 Depends:
     R (>= 3.4.0)
 Imports:
+    arrow,
     askpass,
     assertthat,
     DBI,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,6 @@ Imports:
     lubridate,
     methods,
     odbc,
-    protolite,
     readr,
     rlang,
     stringr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# etn (development version)
+* API functions now use the `arrow` package to transfer data.frames, which should allow for greater amounts of detections to be transferred without crashing (#323, #327). This will also reduce memory usage for large objects, an should generally result in a speedup.
+* etn now requires an R version of at least 4, this is a consequence of the usage of the `arrow` package.
+
 # etn 2.3.0
 
 * **The etn package can now be used on your computer!** It connects to the ETN database with an API provided by the [etnservice](https://github.com/inbo/etnservice) package. All functions make use of this API by default, which may result in **slower response times**. To use the previous method of directly connecting to the database (only possible when working on the [LifeWatch RStudio Server](https://rstudio.lifewatch.be/)), set `api = false` in all functions (#280).

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,6 +162,9 @@ get_val <- function(temp_key, api_domain = "https://opencpu.lifewatch.be") {
     verb = "GET",
     url = glue::glue(
       "{api_domain}",
+      # I'm passing an argument to arrow::write_feather() via OpenCPU, this
+      # feature is currenlty only documented in the NEWS file. Not in the
+      # official documentation of OPENCPU
       'tmp/{temp_key}/R/.val/feather?compression="lz4"',
       .sep = "/"
     ),

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,14 +162,14 @@ get_val <- function(temp_key, api_domain = "https://opencpu.lifewatch.be") {
     verb = "GET",
     url = glue::glue(
       "{api_domain}",
-      "tmp/{temp_key}/R/.val/pb",
+      'tmp/{temp_key}/R/.val/feather?compression="lz4"',
       .sep = "/"
     ),
     times = 5
   ) %>%
     httr::content(as = "raw")
   # read connection
-  api_response <- protolite::unserialize_pb(response_connection)
+  api_response <- arrow::read_feather(response_connection)
   # Return OpenCPU return object
   return(api_response)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -343,7 +343,7 @@ forward_to_api <- function(
     check_opencpu_response(response)
 
     # Fetch the output from the API: call 2
-    return(get_val_rds(extract_temp_key(response)))
+    return(get_val(extract_temp_key(response)))
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,7 +162,7 @@ get_val <- function(temp_key, api_domain = "https://opencpu.lifewatch.be") {
     verb = "GET",
     url = glue::glue(
       "{api_domain}",
-      "tmp/{temp_key}/R/.val/rds",
+      "tmp/{temp_key}/R/.val/feather",
       .sep = "/"
     ),
     times = 5
@@ -170,9 +170,7 @@ get_val <- function(temp_key, api_domain = "https://opencpu.lifewatch.be") {
     httr::content(as = "raw") %>%
     rawConnection()
   # read connection
-  api_response <- response_connection %>%
-    gzcon() %>%
-    readRDS()
+  api_response <- arrow::read_feather(response_connection)
   # close connection
   close(response_connection)
   # Return OpenCPU return object

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,7 +162,7 @@ get_val <- function(temp_key, api_domain = "https://opencpu.lifewatch.be") {
     verb = "GET",
     url = glue::glue(
       "{api_domain}",
-      "tmp/{temp_key}/R/.val/feather",
+      'tmp/{temp_key}/R/.val/feather?compression="lz4"',
       .sep = "/"
     ),
     times = 5

--- a/R/utils.R
+++ b/R/utils.R
@@ -174,28 +174,6 @@ get_val <- function(temp_key, api_domain = "https://opencpu.lifewatch.be") {
   return(api_response)
 }
 
-get_val_rds <- function(temp_key, api_domain = "https://opencpu.lifewatch.be") {
-  # request data and open connection
-  response_connection <- httr::RETRY(
-    verb = "GET",
-    url = glue::glue(
-      "{api_domain}",
-      "tmp/{temp_key}/R/.val/rds",
-      .sep = "/"
-    ),
-    times = 5
-  ) %>%
-    httr::content(as = "raw") %>%
-    rawConnection()
-  # read connection
-  api_response <- response_connection %>%
-    gzcon() %>%
-    readRDS()
-  # close connection
-  close(response_connection)
-  # Return OpenCPU return object
-  return(api_response)
-}
 #' Return the arguments as a named list of the parent environment
 #'
 #' Because the requests to the API are so similar, it's more DRY to pass the

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,15 +162,14 @@ get_val <- function(temp_key, api_domain = "https://opencpu.lifewatch.be") {
     verb = "GET",
     url = glue::glue(
       "{api_domain}",
-      'tmp/{temp_key}/R/.val/feather?compression="lz4"',
+      "tmp/{temp_key}/R/.val/pb",
       .sep = "/"
     ),
     times = 5
   ) %>%
-    httr::content(as = "raw") %>%
-    rawConnection()
+    httr::content(as = "raw")
   # read connection
-  api_response <- arrow::read_feather(response_connection)
+  api_response <- protolite::unserialize_pb(response_connection)
   # Return OpenCPU return object
   return(api_response)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -171,8 +171,6 @@ get_val <- function(temp_key, api_domain = "https://opencpu.lifewatch.be") {
     rawConnection()
   # read connection
   api_response <- arrow::read_feather(response_connection)
-  # close connection
-  close(response_connection)
   # Return OpenCPU return object
   return(api_response)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -175,6 +175,28 @@ get_val <- function(temp_key, api_domain = "https://opencpu.lifewatch.be") {
   return(api_response)
 }
 
+get_val_rds <- function(temp_key, api_domain = "https://opencpu.lifewatch.be") {
+  # request data and open connection
+  response_connection <- httr::RETRY(
+    verb = "GET",
+    url = glue::glue(
+      "{api_domain}",
+      "tmp/{temp_key}/R/.val/rds",
+      .sep = "/"
+    ),
+    times = 5
+  ) %>%
+    httr::content(as = "raw") %>%
+    rawConnection()
+  # read connection
+  api_response <- response_connection %>%
+    gzcon() %>%
+    readRDS()
+  # close connection
+  close(response_connection)
+  # Return OpenCPU return object
+  return(api_response)
+}
 #' Return the arguments as a named list of the parent environment
 #'
 #' Because the requests to the API are so similar, it's more DRY to pass the
@@ -321,7 +343,7 @@ forward_to_api <- function(
     check_opencpu_response(response)
 
     # Fetch the output from the API: call 2
-    return(get_val(extract_temp_key(response)))
+    return(get_val_rds(extract_temp_key(response)))
   }
 }
 


### PR DESCRIPTION
This PR requires changes on the Lifewatch RStudio Server in order to work on there, I want users on the RStudio Server to be able to use the most recent etn version. **If this PR is merged into v2.3.1, then this version will require an update of the R version on the lifewatch server.** 

This PR is serving as a jumping off point for testing by my co-developers. I'd be very grateful for your input! 

Fixes:
- I now use apache arrow for file transfers instead of RDS, which uses lz4 instead of gzip compression and is also chunked:
    - less memory usage for both client and server
    - faster compression/decompression
    - because we need less memory, we can get away with larger objects

Talking points:
- Doesn't actually allow you to load detections for `2013_albertkanaal` this crashes before serialisation on the server side, so I can't fix this on the client side
- Is it actually faster for you?
- You can test memory usage by looking at your resource manager, or via something like `bench::mark()`
- Is the arrow dependency worth it? RDS will become more and more problematic with larger and larger datasets (especially multiple animal_project_codes)


## Alternative approach
The API result object is currently passed as a single binary stream. Instead, I could also try to split it up into multiple files hosted by OpenCPU and to fetch those individually, and combine them. This is more complex and will be more difficult to debug if something goes wrong, but would allow us to keep using rds for now. I haven't tested this yet, as it would disrupt the current v2.3.0 beta. There is a dev env on the horizon that would allow tests like this in the future. 