### PR TITLE
Add (zenodo) DOI to README

### DIFF
--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -39,7 +39,7 @@ jobs:
           # See https://docs.ropensci.org/cffr/articles/cffr.html
 
           # Write your own keys
-          mykeys <- list(doi = "https://doi.org/10.5281/zenodo.15235747")
+          mykeys <- list()
 
           # Create your CITATION.cff file
           cff_write(keys = mykeys)

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -39,7 +39,7 @@ jobs:
           # See https://docs.ropensci.org/cffr/articles/cffr.html
 
           # Write your own keys
-          mykeys <- list()
+          mykeys <- list(doi = "https://doi.org/10.5281/zenodo.15235747")
 
           # Create your CITATION.cff file
           cff_write(keys = mykeys)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ type: software
 license: MIT
 title: 'etn: Access Data from the European Tracking Network'
 version: 2.2.1
-doi: zenodo.15235747
+doi: 10.5281/zenodo.15235747
 abstract: Package with functions to access and process data from the European Tracking
   Network hosted by VLIZ.
 authors:
@@ -52,7 +52,7 @@ preferred-citation:
   year: '2025'
   notes: R package version 2.2.1
   url: https://inbo.github.io/etn/
-  doi: zenodo.15235747
+  doi: 10.5281/zenodo.15235747
 repository-code: https://github.com/inbo/etn
 url: https://inbo.github.io/etn
 contact:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,15 +1,9 @@
-# --------------------------------------------
-# CITATION file created with {cffr} R package
-# See also: https://docs.ropensci.org/cffr/
-# --------------------------------------------
- 
 cff-version: 1.2.0
 message: 'To cite package "etn" in publications use:'
 type: software
 license: MIT
 title: 'etn: Access Data from the European Tracking Network'
 version: 2.2.1
-doi: https://doi.org/10.5281/zenodo.15235747
 abstract: Package with functions to access and process data from the European Tracking
   Network hosted by VLIZ.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,15 @@
+# --------------------------------------------
+# CITATION file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# --------------------------------------------
+ 
 cff-version: 1.2.0
 message: 'To cite package "etn" in publications use:'
 type: software
 license: MIT
 title: 'etn: Access Data from the European Tracking Network'
 version: 2.2.1
+doi: zenodo.15235747
 abstract: Package with functions to access and process data from the European Tracking
   Network hosted by VLIZ.
 authors:
@@ -46,6 +52,7 @@ preferred-citation:
   year: '2025'
   notes: R package version 2.2.1
   url: https://inbo.github.io/etn/
+  doi: zenodo.15235747
 repository-code: https://github.com/inbo/etn
 url: https://inbo.github.io/etn
 contact:
@@ -86,6 +93,7 @@ references:
     given-names: Hadley
     email: hadley@rstudio.com
   year: '2025'
+  doi: 10.32614/CRAN.package.assertthat
 - type: software
   title: DBI
   abstract: 'DBI: R Database Interface'
@@ -101,6 +109,7 @@ references:
     email: kirill@cynkra.com
     orcid: https://orcid.org/0000-0002-1416-3412
   year: '2025'
+  doi: 10.32614/CRAN.package.DBI
 - type: software
   title: dplyr
   abstract: 'dplyr: A Grammar of Data Manipulation'
@@ -125,6 +134,7 @@ references:
     email: davis@posit.co
     orcid: https://orcid.org/0000-0003-4777-038X
   year: '2025'
+  doi: 10.32614/CRAN.package.dplyr
 - type: software
   title: glue
   abstract: 'glue: Interpreted String Literals'
@@ -140,6 +150,7 @@ references:
     email: jenny@posit.co
     orcid: https://orcid.org/0000-0002-6983-2759
   year: '2025'
+  doi: 10.32614/CRAN.package.glue
 - type: software
   title: jsonlite
   abstract: 'jsonlite: A Simple and Robust JSON Parser and Generator for R'
@@ -152,6 +163,7 @@ references:
     email: jeroenooms@gmail.com
     orcid: https://orcid.org/0000-0002-4035-0289
   year: '2025'
+  doi: 10.32614/CRAN.package.jsonlite
 - type: software
   title: lubridate
   abstract: 'lubridate: Make Dealing with Dates a Little Easier'
@@ -167,6 +179,7 @@ references:
   - family-names: Wickham
     given-names: Hadley
   year: '2025'
+  doi: 10.32614/CRAN.package.lubridate
 - type: software
   title: methods
   abstract: 'R: A Language and Environment for Statistical Computing'
@@ -192,6 +205,7 @@ references:
   - family-names: Gjoneski
     given-names: Oliver
   year: '2025'
+  doi: 10.32614/CRAN.package.odbc
 - type: software
   title: readr
   abstract: 'readr: Read Rectangular Text Data'
@@ -208,6 +222,7 @@ references:
     given-names: Jennifer
     email: jenny@posit.co
     orcid: https://orcid.org/0000-0002-6983-2759
+  doi: 10.32614/CRAN.package.readr
   year: '2025'
 - type: software
   title: stringr
@@ -220,6 +235,7 @@ references:
     given-names: Hadley
     email: hadley@posit.co
   year: '2025'
+  doi: 10.32614/CRAN.package.stringr
 - type: software
   title: formattable
   abstract: 'formattable: Create ''Formattable'' Data Structures'
@@ -234,6 +250,7 @@ references:
     given-names: Kenton
     email: kent.russell@timelyportfolio.com
   year: '2025'
+  doi: 10.32614/CRAN.package.formattable
 - type: software
   title: leaflet
   abstract: 'leaflet: Create Interactive Web Maps with the JavaScript ''Leaflet''
@@ -254,6 +271,7 @@ references:
   - family-names: Xie
     given-names: Yihui
   year: '2025'
+  doi: 10.32614/CRAN.package.leaflet
 - type: software
   title: kableExtra
   abstract: 'kableExtra: Construct Complex Table with ''kable'' and Pipe Syntax'
@@ -266,6 +284,7 @@ references:
     email: haozhu233@gmail.com
     orcid: https://orcid.org/0000-0002-3386-6076
   year: '2025'
+  doi: 10.32614/CRAN.package.kableExtra
 - type: software
   title: knitr
   abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
@@ -278,6 +297,7 @@ references:
     email: xie@yihui.name
     orcid: https://orcid.org/0000-0003-0645-5666
   year: '2025'
+  doi: 10.32614/CRAN.package.knitr
 - type: software
   title: rmarkdown
   abstract: 'rmarkdown: Dynamic Documents for R'
@@ -321,6 +341,7 @@ references:
     email: rich@posit.co
     orcid: https://orcid.org/0000-0003-3925-190X
   year: '2025'
+  doi: 10.32614/CRAN.package.rmarkdown
 - type: software
   title: testthat
   abstract: 'testthat: Unit Testing for R'
@@ -332,6 +353,7 @@ references:
     given-names: Hadley
     email: hadley@posit.co
   year: '2025'
+  doi: 10.32614/CRAN.package.testthat
   version: '>= 3.0.0'
 - type: software
   title: tidyr
@@ -349,6 +371,7 @@ references:
   - family-names: Girlich
     given-names: Maximilian
   year: '2025'
+  doi: 10.32614/CRAN.package.tidyr
 - type: software
   title: frictionless
   abstract: 'frictionless: Read and Write Frictionless Data Packages'
@@ -377,6 +400,7 @@ references:
     orcid: https://orcid.org/0000-0002-8939-1305
     affiliation: Research Institute for Nature and Forest (INBO)
   year: '2025'
+  doi: 10.32614/CRAN.package.frictionless
 - type: software
   title: withr
   abstract: 'withr: Run Code ''With'' Temporarily Modified Global State'
@@ -401,4 +425,5 @@ references:
   - family-names: Chang
     given-names: Winston
   year: '2025'
+  doi: 10.32614/CRAN.package.withr
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,15 @@
+# --------------------------------------------
+# CITATION file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# --------------------------------------------
+ 
 cff-version: 1.2.0
 message: 'To cite package "etn" in publications use:'
 type: software
 license: MIT
 title: 'etn: Access Data from the European Tracking Network'
 version: 2.2.1
+doi: https://doi.org/10.5281/zenodo.15235747
 abstract: Package with functions to access and process data from the European Tracking
   Network hosted by VLIZ.
 authors:

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,6 +19,7 @@ knitr::opts_chunk$set(
 [![CRAN status](https://www.r-pkg.org/badges/version/etn)](https://CRAN.R-project.org/package=etn)
 [![repo status](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![R-CMD-check](https://github.com/inbo/etn/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/inbo/etn/actions/workflows/R-CMD-check.yaml)
+[![DOI](https://zenodo.org/badge/95901229.svg)](https://doi.org/10.5281/zenodo.15235747)
 <!-- badges: end -->
 
 Etn provides functionality to access data from the [European Tracking Network (ETN)](http://www.lifewatch.be/etn/) database hosted by the Flanders Marine Institute (VLIZ) as part of the Flemish contribution to LifeWatch. ETN data is subject to the [ETN data policy](http://www.lifewatch.be/etn/assets/docs/ETN-DataPolicy.pdf) and can be:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 status](https://www.r-pkg.org/badges/version/etn)](https://CRAN.R-project.org/package=etn)
 [![repo
 status](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![R-CMD-check](https://github.com/inbo/etn/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/inbo/etn/actions/workflows/R-CMD-check.yaml)
+[![DOI](https://zenodo.org/badge/95901229.svg)](https://doi.org/10.5281/zenodo.15235747)
 <!-- badges: end -->
 
 Etn provides functionality to access data from the [European Tracking
@@ -18,10 +20,10 @@ LifeWatch. ETN data is subject to the [ETN data
 policy](http://www.lifewatch.be/etn/assets/docs/ETN-DataPolicy.pdf) and
 can be:
 
-  - restricted: under moratorium and only accessible to logged-in data
-    owners/collaborators
-  - unrestricted: publicly accessible without login and routinely
-    published to international biodiversity facilities
+- restricted: under moratorium and only accessible to logged-in data
+  owners/collaborators
+- unrestricted: publicly accessible without login and routinely
+  published to international biodiversity facilities
 
 The ETN infrastructure currently requires the package to be run within
 the [LifeWatch.be RStudio server](http://rstudio.lifewatch.be/), which
@@ -40,10 +42,10 @@ devtools::install_github("inbo/etn")
 
 ## Meta
 
-  - We welcome [contributions](.github/CONTRIBUTING.md) including bug
-    reports.
-  - License: MIT
-  - Get citation information for etn in R doing `citation("etn")`.
-  - Please note that this project is released with a [Contributor Code
-    of Conduct](.github/CODE_OF_CONDUCT.md). By participating in this
-    project you agree to abide by its terms.
+- We welcome [contributions](.github/CONTRIBUTING.md) including bug
+  reports.
+- License: MIT
+- Get citation information for etn in R doing `citation("etn")`.
+- Please note that this project is released with a [Contributor Code of
+  Conduct](.github/CODE_OF_CONDUCT.md). By participating in this project
+  you agree to abide by its terms.

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -7,5 +7,6 @@ bibentry(
   author   = authors,
   year     = format(Sys.Date(), "%Y"),
   note = sprintf("R package version %s", meta$Version),
-  url = "https://inbo.github.io/etn/"
+  url = "https://inbo.github.io/etn/",
+  doi = "zenodo.15235747"
 )

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -8,5 +8,5 @@ bibentry(
   year     = format(Sys.Date(), "%Y"),
   note = sprintf("R package version %s", meta$Version),
   url = "https://inbo.github.io/etn/",
-  doi = "zenodo.15235747"
+  doi = "10.5281/zenodo.15235747"
 )


### PR DESCRIPTION
All past releases are now archived to Zenodo #349, every release has it's own DOI. There is also a DOI that refers to all releases, automatically forwarding to the most recent release: https://doi.org/10.5281/zenodo.15235747

This PR adds this DOI to the README page in the form of a badge (Zenodo conveniently already provides the markdown code to do this) by adding it to `README.Rmd` and then building that file to `README.md`. 

By building the README file, I noticed that the R-CMD-CHECK badge was also missing, this badge was automatically added by building. `devtools::build_readme()`. Running this function also changed the formatting slightly. 

## Doubts

~~I updated the `{cffr}` Github action to use a custom key to add the (all version) Zenodo DOI to the  `CITATION.cff file, it'll be automatically added whenever this action runs (on releases).~~

EDIT: I added a line to the `CITATION` file instead, and left the action as is. If there is ever a CRAN release, that second DOI will be added under `identifier`: https://docs.ropensci.org/cffr/news/index.html#cffr-110

However:
- ETN is not on CRAN, so it doesn't have a CRAN DOI.
- If it is ever released to CRAN (hopefully!), it'll get a DOI there, and `{cffr}` is supposed to read it from the `CITATION` file. 
- I'm unsure if the CRAN DOI will be overwritten by the Zenodo DOI.
- The DOI I provided always directs to the most recent version, not neccesairily the version the user is citing when running `citation("etn")`, this might be confusing.

There might be a workaround to get `{cffr}` to update `CITATION.cff` with the Zenodo DOI for the specific release instead of the DOI for all releases, but I didn't investigate this option.

### Changes (AI Summary)

This pull request updates the citation information for the `etn` R package, including the addition of Digital Object Identifiers (DOIs) for the package and its dependencies. It also enhances the documentation to reflect these updates.


* Added a DOI (`zenodo.15235747`) for the `etn` package in the `CITATION.cff` file and the `inst/CITATION` file. [[1]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R1-R12) [[2]](diffhunk://#diff-f36d9cd7ba8ef13c4e62d697ddf4a1bd0f0eabb06a36e8bfb37898aee66976dcL10-R11)
* Included DOIs for all referenced software dependencies in the `CITATION.cff` file, replacing the `type: software` entries. [[1]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R96) [[2]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R112) [[3]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R137) [[4]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R153) [[5]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R166) [[6]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R182) [[7]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R208) [[8]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R225) [[9]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R238) [[10]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R253) [[11]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R274) [[12]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R287) [[13]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R300) [[14]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R344) [[15]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R356) [[16]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R374) [[17]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R403) [[18]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295R428)
* Added a DOI badge to the `README.md` and `README.Rmd` files to make the citation DOI easily accessible. [[1]](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fR22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12-R13)
* Updated the `README.md` to improve the formatting of the Contributor Code of Conduct section.
