### PR TITLE
Add job variable to turn off vcr on repo level

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,6 +29,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       ETN_USER: ${{ secrets.ETN_USER }}
       ETN_PWD: ${{ secrets.ETN_PWD }}
+      VCR_TURN_OFF: ${{ vars.VCR_TURN_OFF }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:

--- a/tests/testthat/_snaps/api/download_acoustic_dataset.md
+++ b/tests/testthat/_snaps/api/download_acoustic_dataset.md
@@ -25,11 +25,11 @@
       
       * number of tags:              16
       
-      * number of detections:        235810
+      * number of detections:        235809
       
-      * number of deployments:       1152
+      * number of deployments:       1036
       
-      * number of receivers:         249
+      * number of receivers:         140
       
       * first date of detection:     2014-04-18
       
@@ -37,7 +37,7 @@
       
       * included scientific names:   Petromyzon marinus, Rutilus rutilus, Silurus glanis, Squalius cephalus
       
-      * included acoustic projects:  albert, demer, dijle, V2LCHASES, zeeschelde
+      * included acoustic projects:  albert, demer, dijle, zeeschelde
       
       
       


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/R-CMD-check.yaml` file. The change introduces a new environment variable, `VCR_TURN_OFF`, to the workflow configuration.

> Use VCR_TURN_OFF=true to suppress all vcr usage, ignoring all cassettes. This is useful for CI/CD workflows where you want to ensure the test suite is run against the live API.

Casettes fail to read under httr2 v1.2.0