### PR TITLE
Add R CMD CHECK runners: old R versions.

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,6 +24,8 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: '3.6.3'}
+          - {os: ubuntu-22.04,   r: '3.4.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,7 +25,6 @@ jobs:
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
           - {os: ubuntu-latest,   r: '3.6.3'}
-          - {os: ubuntu-22.04,   r: '3.4.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,6 +24,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          # And minimum supported version in DESCRIPTION
           - {os: ubuntu-latest,   r: '3.6.3'}
 
     env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0),
     tidyr,
-    vcr (>= 2.0.0),
+    vcr,
     withr
 VignetteBuilder: 
     knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ License: MIT + file LICENSE
 URL: https://github.com/inbo/etn, https://inbo.github.io/etn
 BugReports: https://github.com/inbo/etn/issues
 Depends:
-    R (>= 3.4.0)
+    R (>= 3.6.3)
 Imports:
     askpass,
     assertthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,8 +51,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:  
-    inbo/etnservice,
-    ropensci/vcr
+    inbo/etnservice
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
`{etn}` is used on some systems running old R versions, and the package declares a minimum version of R3.4.0, the VLIZ Rstudio Server is on R3.6.3.

This PR adds R CMD CHECK runners for those versions, so we have some security going forward that it actually works for these old R releases. 

I couldn't set the OS to the same one used on the RStudio Server, because such old runners are no longer supported. 