### PR TITLE
Client can switch to etnservice test deployment.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Queries via the API and on the Lifewatch RStudio Server will now always return the same results. (#317)
 * You can now store your password and username in `.Renviron` (easy to edit with `usethis::edit_r_environ()`), specifically in `ETN_USER` and `ETN_PWD` (#317, #339, #338, #228)
 * Archival tags are now available in `get_animals()` (#365). 
+* Contributors can now change the default domain of the API to the url of a test deployment by setting the environmental variable `ETN_TEST_API`. (#383)
 
 # etn 2.2.2
 

--- a/R/forward_to_api.R
+++ b/R/forward_to_api.R
@@ -15,7 +15,7 @@
 #' @noRd
 forward_to_api <- function(
     function_identity,
-    payload,
+    payload = list(),
     add_credentials = TRUE,
     json = FALSE,
     domain = "https://opencpu.lifewatch.be/library/etnservice/R") {

--- a/R/forward_to_api.R
+++ b/R/forward_to_api.R
@@ -8,7 +8,9 @@
 #' @param json Logical, if TRUE, then a one step process is used the output is
 #'   parsed from a json response
 #' @param domain Character vector of the OpenCPU domain to use, defaults to
-#'   "https://opencpu.lifewatch.be/library/etnservice/R"
+#'   "https://opencpu.lifewatch.be/library/etnservice/R". A test domain can be
+#'   set via the environmental variable `ETN_TEST_API`. VLIZ has requested the
+#'   authors to not disclose this test url.
 #' @return The same return object of the `function_identity` function
 #'
 #' @family helper functions

--- a/R/forward_to_api.R
+++ b/R/forward_to_api.R
@@ -18,7 +18,8 @@ forward_to_api <- function(
     payload = list(),
     add_credentials = TRUE,
     json = FALSE,
-    domain = "https://opencpu.lifewatch.be/library/etnservice/R") {
+    domain = Sys.getenv("ETN_TEST_API",
+                        unset = "https://opencpu.lifewatch.be/library/etnservice/R")) {
   # Get credentials and attach to payload
   if (add_credentials) {
     # Get credentials out of .Renviron or prompt user.

--- a/tests/testthat/test-forward_to_api.R
+++ b/tests/testthat/test-forward_to_api.R
@@ -40,6 +40,22 @@ test_that("forward_to_api() can send requests to domains other than etn", {
   )
 })
 
+test_that("forward_to_api() can send requests to test domain", {
+  skip_if(Sys.getenv("ETN_TEST_API", unset = "True") == "True",
+    message = "ETN_TEST_API is not set to test deployment url."
+  )
+
+  expect_type(
+    forward_to_api(
+      function_identity = "list_scientific_names",
+      payload = list(),
+      add_credentials = TRUE,
+      json = TRUE
+    ),
+    "character"
+  )
+})
+
 test_that("forward_to_api() can forward R errors to client console", {
   expect_error(
     forward_to_api("rnorm",


### PR DESCRIPTION
`etnservice` can be automatically deployed to a test instance of the API hosted at a secret url. To develop new functions in `etn` and to test the functionality of `etnservice` it is convenient to quickly and easily switch between the production and test deployments. 

This PR adds a `Sys.getenv()` call to `forward_to_api()` so that if this environmental variable is set, the value of this variable is used instead of the production API endpoint: https://opencpu.lifewatch.be/library/etnservice/

This PR also makes a small change to `forward_to_api()` so you can just omit the `payload` argument if you intend to send a request without a payload. 

This PR is merged into the v2.3.1 branch, which is the branch I'm developing the next major release of ETN on. It does not go into production just yet.