### PR TITLE
Refactor `get_acoustic_detections()` to fix bug in local database queries.

### DIFF
--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -163,13 +163,13 @@ get_acoustic_detections <- function(connection,
   )
 
   # Initialize progress bar with total number of pages expected
-  cli::cli_progress_bar(total = ceiling(n_records_expected/page_size))
+  cli::cli_progress_bar(total = ceiling(n_records_expected / page_size))
 
   # Init object to store pages
   combined_results <- list()
 
   # Fetch credentials only once and reuse for every page
-  if(!api) credentials <- get_credentials()
+  if (!api) credentials <- get_credentials()
 
   repeat {
 
@@ -190,19 +190,19 @@ get_acoustic_detections <- function(connection,
       do.call(
         # Either use the API, or the SQL helper
         if (api) forward_to_api else etnservice::get_acoustic_detections_page,
-        args = if(api){
+        args = if (api) {
           # Calls to forward_to_api expect the arguments to be a in a payload
           # object
           list(
             function_identity = "get_acoustic_detections_page",
             append(arguments_to_pass, pagination_arguments)
           )
-          } else {
-            # Direct query to database via etnservice expect a the arguments to
-            # be flat and doesn't need function_identity
-            append(arguments_to_pass, pagination_arguments) |>
-              purrr::list_flatten()
-          }
+        } else {
+          # Direct query to database via etnservice expect a the arguments to
+          # be flat and doesn't need function_identity
+          append(arguments_to_pass, pagination_arguments) |>
+            purrr::list_flatten()
+        }
       )
 
     # The next page will be fetched with detection_ids higher than the current

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -170,10 +170,7 @@ get_acoustic_detections <- function(connection,
   # Fetch credentials only once and reuse for every page
   if(!api) credentials <- get_credentials()
 
-
-
   repeat {
-
     # Pagination arguments
     # If not set, next_id_pk starts at 0 (used to paginate), page_size at 100k.
     # Also includes credentials.
@@ -185,26 +182,22 @@ get_acoustic_detections <- function(connection,
         ifnotfound = list(0, 100000, NULL),
         inherits = FALSE
       )
+    # Combine arguments to pass to helper function
+    payload <- append(arguments_to_pass, pagination_arguments)
 
-    # Fetch a page of results
-    fetched_page <-
-      do.call(
-        # Either use the API, or the SQL helper
-        if (api) forward_to_api else etnservice::get_acoustic_detections_page,
-        args = if(api){
-          # Calls to forward_to_api expect the arguments to be a in a payload
-          # object
-          list(
-            function_identity = "get_acoustic_detections_page",
-            append(arguments_to_pass, pagination_arguments)
-          )
-          } else {
-            # Direct query to database via etnservice expect a the arguments to
-            # be flat and doesn't need function_identity
-            append(arguments_to_pass, pagination_arguments) |>
-              list_flatten()
-          }
-      )
+    # Decide what helper to use, add any extra required arguments
+    if(api){
+      helper_to_use <- forward_to_api
+      arguments_for_helper <-
+        list(function_identity = "get_acoustic_detections_page",
+           payload = payload)
+    } else {
+      helper_to_use <- etnservice::get_acoustic_detections_page
+      arguments_for_helper <- payload
+    }
+
+    # Fetch page
+    fetched_page <- do.call(helper_to_use, arguments_for_helper)
 
     # Iterate the progress bar
     cli::cli_progress_update(inc = nrow(fetched_page))

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -202,7 +202,7 @@ get_acoustic_detections <- function(connection,
             # Direct query to database via etnservice expect a the arguments to
             # be flat and doesn't need function_identity
             append(arguments_to_pass, pagination_arguments) |>
-              purrr::list_flatten()
+              list_flatten()
           }
       )
 

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -167,34 +167,53 @@ get_acoustic_detections <- function(connection,
   # Init object to store pages
   combined_results <- list()
 
-  # Fetch credentials in case of local query
+  # Fetch credentials only once and reuse for every page
   if(!api) credentials <- get_credentials()
 
-  # Append the arguments_to_pass with additional elements needed for helpers, drop the elements if not needed
-  arguments_to_pass <-
-    list(
-      # function_identity is ignored by
-      # etnservice::get_acoustic_detections_paged and sent to ...
-      function_identity = "get_acoustic_detections_page",
-      append(
-        arguments_to_pass,
-        # use the next_id_pk to paginate, if we are on the first page, start
-        # at 0
-        mget(
-          # Get the following objects from the enclosing frame
-          c("next_id_pk", "page_size", "credentials"),
-          # With the following default values if not set:
-          ifnotfound = list(0, 100000, NULL),
-          inherits = FALSE
-        ),
-        after = 0
-      )
-    ) |>
-    purrr::list_flatten() |>
-    # drop any arguments that have no value
-    purrr::discard(is.null)
+
 
   repeat {
+
+    # Append the arguments_to_pass with additional elements needed for the
+    # respective helpers
+    if(api){
+      # Calls to forward_to_api expect the arguments to be a in a payload object
+      arguments_to_pass <-
+        list(
+          function_identity = "get_acoustic_detections_page",
+          append(
+            arguments_to_pass,
+            # use the next_id_pk to paginate, if we are on the first page, start
+            # at 0
+            mget(
+              # Get the following objects from the enclosing frame
+              c("next_id_pk", "page_size", "credentials"),
+              # With the following default values if not set:
+              ifnotfound = list(0, 100000, NULL),
+              inherits = FALSE
+            ),
+            after = 0
+          )
+        )
+    } else {
+      # Direct query to database via etnservice expect a the arguments to be
+      # flat and don't need function_identity
+      arguments_to_pass <-
+        append(
+          arguments_to_pass,
+          credentials = credentials,
+          mget(
+            # Get the following objects from the enclosing frame
+            c("next_id_pk", "page_size"),
+            # With the following default values if not set:
+            ifnotfound = list(0, 100000),
+            inherits = FALSE
+          )
+        ) |>
+        purrr::list_flatten()
+    }
+
+    # Fetch a page of results
     fetched_page <-
       do.call(
         # Either use the API, or the SQL helper

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -154,9 +154,6 @@ get_acoustic_detections <- function(connection,
     )
   }
 
-  # Initialise progress bar with total records expected
-  cli::cli_progress_bar(total = n_records_expected)
-
   # Control number of objects to fetch per page, 100k default, up to 1M for
   # big queries
   page_size <- dplyr::case_when(
@@ -165,13 +162,14 @@ get_acoustic_detections <- function(connection,
     .default = 100000
   )
 
+  # Initialize progress bar with total number of pages expected
+  cli::cli_progress_bar(total = ceiling(n_records_expected/page_size))
+
   # Init object to store pages
   combined_results <- list()
 
   # Fetch credentials only once and reuse for every page
   if(!api) credentials <- get_credentials()
-
-
 
   repeat {
 
@@ -207,15 +205,15 @@ get_acoustic_detections <- function(connection,
           }
       )
 
-    # Iterate the progress bar
-    cli::cli_progress_update(inc = nrow(fetched_page))
-
     # The next page will be fetched with detection_ids higher than the current
     # max detection_id
     next_id_pk <- max(fetched_page$detection_id)
 
     # store page: use next_id_pk as name to avoid iterating page number
     combined_results[[as.character(next_id_pk)]] <- fetched_page
+
+    # Iterate the progress bar: we fetched one page
+    cli::cli_progress_update(inc = 1)
 
     if (nrow(fetched_page) < page_size || limit) {
       # Page isn't full = end of results.

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -174,50 +174,36 @@ get_acoustic_detections <- function(connection,
 
   repeat {
 
-    # Append the arguments_to_pass with additional elements needed for the
-    # respective helpers
-    if(api){
-      # Calls to forward_to_api expect the arguments to be a in a payload object
-      arguments_to_pass <-
-        list(
-          function_identity = "get_acoustic_detections_page",
-          append(
-            arguments_to_pass,
-            # use the next_id_pk to paginate, if we are on the first page, start
-            # at 0
-            mget(
-              # Get the following objects from the enclosing frame
-              c("next_id_pk", "page_size", "credentials"),
-              # With the following default values if not set:
-              ifnotfound = list(0, 100000, NULL),
-              inherits = FALSE
-            ),
-            after = 0
-          )
-        )
-    } else {
-      # Direct query to database via etnservice expect a the arguments to be
-      # flat and don't need function_identity
-      arguments_to_pass <-
-        append(
-          arguments_to_pass,
-          mget(
-            # Get the following objects from the enclosing frame
-            c("next_id_pk", "page_size", "credentials"),
-            # With the following default values if not set:
-            ifnotfound = list(0, 100000, NULL),
-            inherits = FALSE
-          )
-        ) |>
-        purrr::list_flatten()
-    }
+    # Pagination arguments
+    # If not set, next_id_pk starts at 0 (used to paginate), page_size at 100k.
+    # Also includes credentials.
+    pagination_arguments <-
+      mget(
+        # Get the following objects from the enclosing frame
+        c("next_id_pk", "page_size", "credentials"),
+        # With the following default values if not set:
+        ifnotfound = list(0, 100000, NULL),
+        inherits = FALSE
+      )
 
     # Fetch a page of results
     fetched_page <-
       do.call(
         # Either use the API, or the SQL helper
         if (api) forward_to_api else etnservice::get_acoustic_detections_page,
-        args = arguments_to_pass
+        args = if(api){
+          # Calls to forward_to_api expect the arguments to be a in a payload
+          # object
+          list(
+            function_identity = "get_acoustic_detections_page",
+            append(arguments_to_pass, pagination_arguments)
+          )
+          } else {
+            # Direct query to database via etnservice expect a the arguments to
+            # be flat and doesn't need function_identity
+            append(arguments_to_pass, pagination_arguments) |>
+              purrr::list_flatten()
+          }
       )
 
     # Iterate the progress bar

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -172,7 +172,6 @@ get_acoustic_detections <- function(connection,
   if (!api) credentials <- get_credentials()
 
   repeat {
-
     # Pagination arguments
     # If not set, next_id_pk starts at 0 (used to paginate), page_size at 100k.
     # Also includes credentials.
@@ -189,11 +188,13 @@ get_acoustic_detections <- function(connection,
     payload <- append(arguments_to_pass, pagination_arguments)
 
     # Decide what helper to use, add any extra required arguments
-    if(api){
+    if (api) {
       helper_to_use <- forward_to_api
       arguments_for_helper <-
-        list(function_identity = "get_acoustic_detections_page",
-             payload = payload)
+        list(
+          function_identity = "get_acoustic_detections_page",
+          payload = payload
+        )
     } else {
       helper_to_use <- etnservice::get_acoustic_detections_page
       arguments_for_helper <- payload

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -185,25 +185,25 @@ get_acoustic_detections <- function(connection,
         inherits = FALSE
       )
 
-    # Fetch a page of results
-    fetched_page <-
-      do.call(
-        # Either use the API, or the SQL helper
-        if (api) forward_to_api else etnservice::get_acoustic_detections_page,
-        args = if (api) {
-          # Calls to forward_to_api expect the arguments to be a in a payload
-          # object
-          list(
-            function_identity = "get_acoustic_detections_page",
-            append(arguments_to_pass, pagination_arguments)
-          )
-        } else {
-          # Direct query to database via etnservice expect a the arguments to
-          # be flat and doesn't need function_identity
-          append(arguments_to_pass, pagination_arguments) |>
-            purrr::list_flatten()
-        }
-      )
+    # Combine arguments to pass to helper function
+    payload <- append(arguments_to_pass, pagination_arguments)
+
+    # Decide what helper to use, add any extra required arguments
+    if(api){
+      helper_to_use <- forward_to_api
+      arguments_for_helper <-
+        list(function_identity = "get_acoustic_detections_page",
+             payload = payload)
+    } else {
+      helper_to_use <- etnservice::get_acoustic_detections_page
+      arguments_for_helper <- payload
+    }
+
+    # Fetch page
+    fetched_page <- do.call(helper_to_use, arguments_for_helper)
+
+    # Iterate the progress bar
+    cli::cli_progress_update(inc = nrow(fetched_page))
 
     # The next page will be fetched with detection_ids higher than the current
     # max detection_id

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -167,29 +167,39 @@ get_acoustic_detections <- function(connection,
   # Init object to store pages
   combined_results <- list()
 
+  # Fetch credentials in case of local query
+  if(!api) credentials <- get_credentials()
+
+  # Append the arguments_to_pass with additional elements needed for helpers, drop the elements if not needed
+  arguments_to_pass <-
+    list(
+      # function_identity is ignored by
+      # etnservice::get_acoustic_detections_paged and sent to ...
+      function_identity = "get_acoustic_detections_page",
+      append(
+        arguments_to_pass,
+        # use the next_id_pk to paginate, if we are on the first page, start
+        # at 0
+        mget(
+          # Get the following objects from the enclosing frame
+          c("next_id_pk", "page_size", "credentials"),
+          # With the following default values if not set:
+          ifnotfound = list(0, 100000, NULL),
+          inherits = FALSE
+        ),
+        after = 0
+      )
+    ) |>
+    purrr::list_flatten() |>
+    # drop any arguments that have no value
+    purrr::discard(is.null)
+
   repeat {
     fetched_page <-
       do.call(
         # Either use the API, or the SQL helper
         if (api) forward_to_api else etnservice::get_acoustic_detections_page,
-        args = list(
-          # function_identity is ignored by
-          # etnservice::get_acoustic_detections_paged and sent to ...
-          function_identity = "get_acoustic_detections_page",
-          append(
-            arguments_to_pass,
-            # use the next_id_pk to paginate, if we are on the first page, start
-            # at 0
-            mget(
-              # Get the following objects from the enclosing frame
-              c("next_id_pk", "page_size"),
-              # With the following default values if not set:
-              ifnotfound = list(0, 100000),
-              inherits = FALSE
-            ),
-            after = 0
-          )
-        )
+        args = arguments_to_pass
       )
 
     # Iterate the progress bar

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -113,16 +113,17 @@ get_acoustic_detections <- function(connection,
 
   # Calculate the number of records we expect: for progress bar + page_size
   n_records_expected <-
-    ifelse(
-      limit,
+    if (limit) {
       # If limit is set to TRUE, we expect 100 records
-      100,
+      100
+    } else {
       # otherwise query the number of records
+
       do.call(count_acoustic_detections, append(
         arguments_to_pass,
         list(api = api)
       ))
-    )
+    }
 
   # Return early if query didn't result in any rows
   if (n_records_expected == 0) {
@@ -170,7 +171,10 @@ get_acoustic_detections <- function(connection,
   # Fetch credentials only once and reuse for every page
   if(!api) credentials <- get_credentials()
 
+
+
   repeat {
+
     # Pagination arguments
     # If not set, next_id_pk starts at 0 (used to paginate), page_size at 100k.
     # Also includes credentials.
@@ -182,22 +186,26 @@ get_acoustic_detections <- function(connection,
         ifnotfound = list(0, 100000, NULL),
         inherits = FALSE
       )
-    # Combine arguments to pass to helper function
-    payload <- append(arguments_to_pass, pagination_arguments)
 
-    # Decide what helper to use, add any extra required arguments
-    if(api){
-      helper_to_use <- forward_to_api
-      arguments_for_helper <-
-        list(function_identity = "get_acoustic_detections_page",
-           payload = payload)
-    } else {
-      helper_to_use <- etnservice::get_acoustic_detections_page
-      arguments_for_helper <- payload
-    }
-
-    # Fetch page
-    fetched_page <- do.call(helper_to_use, arguments_for_helper)
+    # Fetch a page of results
+    fetched_page <-
+      do.call(
+        # Either use the API, or the SQL helper
+        if (api) forward_to_api else etnservice::get_acoustic_detections_page,
+        args = if(api){
+          # Calls to forward_to_api expect the arguments to be a in a payload
+          # object
+          list(
+            function_identity = "get_acoustic_detections_page",
+            append(arguments_to_pass, pagination_arguments)
+          )
+          } else {
+            # Direct query to database via etnservice expect a the arguments to
+            # be flat and doesn't need function_identity
+            append(arguments_to_pass, pagination_arguments) |>
+              purrr::list_flatten()
+          }
+      )
 
     # Iterate the progress bar
     cli::cli_progress_update(inc = nrow(fetched_page))

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -201,12 +201,11 @@ get_acoustic_detections <- function(connection,
       arguments_to_pass <-
         append(
           arguments_to_pass,
-          credentials = credentials,
           mget(
             # Get the following objects from the enclosing frame
-            c("next_id_pk", "page_size"),
+            c("next_id_pk", "page_size", "credentials"),
             # With the following default values if not set:
-            ifnotfound = list(0, 100000),
+            ifnotfound = list(0, 100000, NULL),
             inherits = FALSE
           )
         ) |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -127,25 +127,6 @@ is_testing <- function() {
   identical(Sys.getenv("TESTTHAT"), "true")
 }
 
-#' Flatten a list
-#'
-#' A base equivalent to purrr::list_flatten(): recursively flattens a list
-#' of lists into a single list.
-#'
-#' This is used to flatten the list of arguments passed to the etnservice API
-#' functions.
-#'
-#' @param x A list
-#' @return A flattened list
-#' @family helper functions
-#' @noRd
-#' @examples
-#' x <- list(a = 1, b = list(c = 2, d = 3))
-#' list_flatten(x)
-list_flatten <- function(x) {
-  do.call(c, x)
-}
-
 # WRAPPER FUNCTIONS ----
 
 #' Wrapper of askpass::askpass

--- a/R/utils.R
+++ b/R/utils.R
@@ -127,6 +127,25 @@ is_testing <- function() {
   identical(Sys.getenv("TESTTHAT"), "true")
 }
 
+#' Flatten a list
+#'
+#' A base equivalent to purrr::list_flatten(): recursively flattens a list
+#' of lists into a single list.
+#'
+#' This is used to flatten the list of arguments passed to the etnservice API
+#' functions.
+#'
+#' @param x A list
+#' @return A flattened list
+#' @family helper functions
+#' @noRd
+#' @examples
+#' x <- list(a = 1, b = list(c = 2, d = 3))
+#' list_flatten(x)
+list_flatten <- function(x) {
+  do.call(c, x)
+}
+
 # WRAPPER FUNCTIONS ----
 
 #' Wrapper of askpass::askpass

--- a/tests/fixtures/detections_acoustic_and_acoustic_archival_tags.yml
+++ b/tests/fixtures/detections_acoustic_and_acoustic_archival_tags.yml
@@ -7,22 +7,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:47 GMT
+      date: Fri, 19 Sep 2025 12:08:01 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0782ad23c6b366
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0782ad23c6b366/
+      x-ocpu-session: x087332d5a138be
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x087332d5a138be/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:49 UTC
+      x-ocpu-time: 2025-09-19 12:08:03 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -30,7 +30,7 @@ http_interactions:
       content-length: '48'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
         [
@@ -38,31 +38,31 @@ http_interactions:
             "count": 10994
           }
         ]
-  recorded_at: 2025-09-10 14:55:49
+  recorded_at: 2025-09-19 12:08:03
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":null,"acoustic_tag_id":"A69-1601-16130","animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":"A69-1601-16130","animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:49 GMT
+      date: Fri, 19 Sep 2025 12:08:03 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x02e6454eff9199
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x02e6454eff9199/
+      x-ocpu-session: x074cf085b99bf9
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x074cf085b99bf9/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:51 UTC
+      x-ocpu-time: 2025-09-19 12:08:05 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -70,25 +70,25 @@ http_interactions:
       content-length: '137'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x02e6454eff9199/R/.val
-        /ocpu/tmp/x02e6454eff9199/R/credentials
-        /ocpu/tmp/x02e6454eff9199/R/get_acoustic_detections_page
-        /ocpu/tmp/x02e6454eff9199/stdout
-        /ocpu/tmp/x02e6454eff9199/source
-        /ocpu/tmp/x02e6454eff9199/console
-        /ocpu/tmp/x02e6454eff9199/info
-        /ocpu/tmp/x02e6454eff9199/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:55:51
+        /ocpu/tmp/x074cf085b99bf9/R/.val
+        /ocpu/tmp/x074cf085b99bf9/R/credentials
+        /ocpu/tmp/x074cf085b99bf9/R/get_acoustic_detections_page
+        /ocpu/tmp/x074cf085b99bf9/stdout
+        /ocpu/tmp/x074cf085b99bf9/source
+        /ocpu/tmp/x074cf085b99bf9/console
+        /ocpu/tmp/x074cf085b99bf9/info
+        /ocpu/tmp/x074cf085b99bf9/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:08:05
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x02e6454eff9199/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x074cf085b99bf9/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:55:51 GMT
+      date: Fri, 19 Sep 2025 12:08:05 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -102,7 +102,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:52 UTC
+      x-ocpu-time: 2025-09-19 12:08:06 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -3259,7 +3259,7 @@ http_interactions:
         dLLcnXpxf+rXg+tO65ONC18vJhfT9VSXs8F0NlmMB/PNCPeEZ9fz0XhwPrmsaXzz+2hw
         fjm8
         qPu5H+bVmjmbaVbVv/8B1qicaw==
-  recorded_at: 2025-09-10 14:55:52
+  recorded_at: 2025-09-19 12:08:06
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -3268,22 +3268,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:52 GMT
+      date: Fri, 19 Sep 2025 12:08:06 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x08c4763d9237fe
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x08c4763d9237fe/
+      x-ocpu-session: x0199414e9bb381
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0199414e9bb381/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:54 UTC
+      x-ocpu-time: 2025-09-19 12:08:07 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -3299,58 +3299,58 @@ http_interactions:
             "count": 1276
           }
         ]
-  recorded_at: 2025-09-10 14:55:54
+  recorded_at: 2025-09-19 12:08:08
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":null,"acoustic_tag_id":["A69-9006-11100","A69-9006-11099"],"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":["A69-9006-11100","A69-9006-11099"],"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:54 GMT
+      date: Fri, 19 Sep 2025 12:08:08 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0c9e61725d26b0
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0c9e61725d26b0/
+      x-ocpu-session: x01cf1da0feaa5f
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x01cf1da0feaa5f/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:56 UTC
+      x-ocpu-time: 2025-09-19 12:08:09 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '145'
+      content-length: '142'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
-        /ocpu/tmp/x0c9e61725d26b0/R/.val
-        /ocpu/tmp/x0c9e61725d26b0/R/acoustic_tag_id
-        /ocpu/tmp/x0c9e61725d26b0/R/credentials
-        /ocpu/tmp/x0c9e61725d26b0/R/get_acoustic_detections_page
-        /ocpu/tmp/x0c9e61725d26b0/stdout
-        /ocpu/tmp/x0c9e61725d26b0/source
-        /ocpu/tmp/x0c9e61725d26b0/console
-        /ocpu/tmp/x0c9e61725d26b0/info
-        /ocpu/tmp/x0c9e61725d26b0/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:55:56
+        /ocpu/tmp/x01cf1da0feaa5f/R/.val
+        /ocpu/tmp/x01cf1da0feaa5f/R/acoustic_tag_id
+        /ocpu/tmp/x01cf1da0feaa5f/R/credentials
+        /ocpu/tmp/x01cf1da0feaa5f/R/get_acoustic_detections_page
+        /ocpu/tmp/x01cf1da0feaa5f/stdout
+        /ocpu/tmp/x01cf1da0feaa5f/source
+        /ocpu/tmp/x01cf1da0feaa5f/console
+        /ocpu/tmp/x01cf1da0feaa5f/info
+        /ocpu/tmp/x01cf1da0feaa5f/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:08:09
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0c9e61725d26b0/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x01cf1da0feaa5f/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:55:56 GMT
+      date: Fri, 19 Sep 2025 12:08:09 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -3364,7 +3364,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:56 UTC
+      x-ocpu-time: 2025-09-19 12:08:10 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -3372,7 +3372,7 @@ http_interactions:
       content-length: '12072'
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       raw_gzip: |-
         eJztfQl41NX19iC4IKK04tKKGBUVKULCDm64tlptXXBDMQYIa0hYAqJWRTJxq9ZaN9QWwiST
@@ -3802,5 +3802,5 @@ http_interactions:
         J5diqOVlhaVlU+cUF87e1sPtDZfNnT2huH
         DS1BLXxt6zJhROKima7J7Dbs5AcLYNMxBo/V9C
         oiQv
-  recorded_at: 2025-09-10 14:55:57
+  recorded_at: 2025-09-19 12:08:10
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_animal_project_code.yml
+++ b/tests/fixtures/detections_animal_project_code.yml
@@ -7,22 +7,22 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:51:48 GMT
+      date: Fri, 19 Sep 2025 12:04:21 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x03c319853b7abd
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x03c319853b7abd/
+      x-ocpu-session: x0ea56a2d4873ec
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0ea56a2d4873ec/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:50 UTC
+      x-ocpu-time: 2025-09-19 12:04:22 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -54,7 +54,7 @@ http_interactions:
         hg3pHaLGkFuLtCL0vJwUZnUydK0b18PeeVvxvF3z66W6mYfza9KoJW7mjkCT7/JsuaVC8L
         Ss
         TB6mKnPH48i7SLtZp1Dnr8sdDn4BsBw88Q==
-  recorded_at: 2025-09-10 14:51:50
+  recorded_at: 2025-09-19 12:04:22
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -63,22 +63,22 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:51:50 GMT
+      date: Fri, 19 Sep 2025 12:04:22 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x075feb2ef239c3
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x075feb2ef239c3/
+      x-ocpu-session: x058df78ac5ea6a
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x058df78ac5ea6a/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:51 UTC
+      x-ocpu-time: 2025-09-19 12:04:23 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -110,7 +110,7 @@ http_interactions:
         NnPOwLkYc8aNGavrsCO9Q9QYcmuRVoSelxeVWbyYuKtL2mFvvK142q7scq6usjC7JI1W4i
         pz
         BJr8kGfNLTWCh3VjyjBXhTtOIq+QfrMOoc3ftjs5+AWdDENn
-  recorded_at: 2025-09-10 14:51:52
+  recorded_at: 2025-09-19 12:04:23
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -119,22 +119,159 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:52 GMT
+      date: Fri, 19 Sep 2025 12:04:23 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0ffc707707a19a
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0ffc707707a19a/
+      x-ocpu-session: x00f954c27a4612
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x00f954c27a4612/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:54 UTC
+      x-ocpu-time: 2025-09-19 12:04:25 UTC
+      x-ocpu-version: 2.2.14
+      x-ocpu-server: rApache
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-length: '44'
+      content-type: application/json
+      access-control-allow-methods: '*'
+      set-cookie: vliz_webc=vliz_webc1; path=/
+    body:
+      string: |
+        [
+          {
+            "count": 4
+          }
+        ]
+  recorded_at: 2025-09-19 12:04:25
+- request:
+    method: POST
+    uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
+    body:
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2015-09-07","end_date":"2015-09-08","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
+  response:
+    status: 201
+    headers:
+      date: Fri, 19 Sep 2025 12:04:25 GMT
+      server: Apache/2.4.58 (Ubuntu)
+      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
+        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
+        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
+      cross-origin-opener-policy: same-origin
+      cache-control: max-age=300, public
+      x-ocpu-session: x08b033dd4ecabb
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x08b033dd4ecabb/
+      access-control-allow-origin: '*'
+      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
+      access-control-allow-headers: '*'
+      access-control-allow-credentials: 'true'
+      x-ocpu-r: R version 4.5.0 (2025-04-11)
+      x-ocpu-locale: C.UTF-8
+      x-ocpu-time: 2025-09-19 12:04:27 UTC
+      x-ocpu-version: 2.2.14
+      x-ocpu-server: rApache
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-length: '136'
+      content-type: text/plain; charset=utf-8
+      access-control-allow-methods: '*'
+      set-cookie: vliz_webc=vliz_webc2; path=/
+    body:
+      string: |
+        /ocpu/tmp/x08b033dd4ecabb/R/.val
+        /ocpu/tmp/x08b033dd4ecabb/R/credentials
+        /ocpu/tmp/x08b033dd4ecabb/R/get_acoustic_detections_page
+        /ocpu/tmp/x08b033dd4ecabb/stdout
+        /ocpu/tmp/x08b033dd4ecabb/source
+        /ocpu/tmp/x08b033dd4ecabb/console
+        /ocpu/tmp/x08b033dd4ecabb/info
+        /ocpu/tmp/x08b033dd4ecabb/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:04:27
+- request:
+    method: GET
+    uri: https://opencpu.lifewatch.be/tmp/x08b033dd4ecabb/R/.val/rds
+  response:
+    status: 200
+    headers:
+      date: Fri, 19 Sep 2025 12:04:27 GMT
+      server: Apache/2.4.58 (Ubuntu)
+      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
+        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
+        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
+      cross-origin-opener-policy: same-origin
+      cache-control: max-age=86400, public
+      content-disposition: attachment;filename=.val.rds
+      access-control-allow-origin: '*'
+      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
+      access-control-allow-headers: '*'
+      access-control-allow-credentials: 'true'
+      x-ocpu-r: R version 4.5.0 (2025-04-11)
+      x-ocpu-locale: C.UTF-8
+      x-ocpu-time: 2025-09-19 12:04:27 UTC
+      x-ocpu-version: 2.2.14
+      x-ocpu-server: rApache
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-length: '653'
+      content-type: application/r-rds
+      access-control-allow-methods: '*'
+      set-cookie: vliz_webc=vliz_webc1; path=/
+    body:
+      raw_gzip: |-
+        eJytVTFvEzEUdpqUkDZtGrVdmNiYEuWuTdJsqSqBKiRAbQrdLNfnBMPduT37Ai0DSAzdGNiY
+        QPwAVia
+        kbgwMLCABv4Id1PKcnK+5E0W0yknvnt/n5+/5vfPzbU8hhLIoNwlvEIQmtzrXKytg
+        zYOxADIDksuo/K
+        vM/tE3kO8gP2B+VuOrX58cPn6GEOjnGtDabg/1pyPNl5uAVwblUEGTU5dI
+        CYM5kIkIzN+5vbm+TVVkX
+        hqYKr1SHQifRSsNmN3qrIE6juCcIbSsptVcsc5nJjlmVxutitWo
+        WRW7UV+qjwFN8k/ZNWsZO8xjwQWR
+        6MtANfaSksxjk7thEMqrPZf4XI4BTeVxwJik95nrsAsi
+        Sb7puxv2vYpl2XarnoTsZtNq/SeU5MxKOND
+        DYQ6G5MwxJKvH7fWXneLHF69BL699eXgtrWO/
+        8sb748vvfrXLt24efvicTWvj9/SnboT827N0vF2ECi
+        fw/EOPm29whKB/0aikyndFVxYPPwmG
+        A9io2fYStqpU9pMeg9obD3uMHufMB+6QNyA3TkVfJZmTiCdrL
+        hq142Knaw4JWOZ0OkSRajcg
+        HkvdQoVAPKr6gMso1oSuF4T+nb6ujJMOuBCBRYcpRhUXPuaOYYRYDCvu
+        mdYoK9LDkgWcuNgP
+        vZ2490uEilAqTrH2iAnmoSk98N0NxAMgx1TEXVaIpmLfkqSc+Yp3gURvMIIXY+a
+        /kEwHjDLe
+        Z8EpTVEqMshihKPksF1X7GMXZlQYr54zsPB7o3hRMl+KAPeJG8aRIiz0ufkXzAwhO+FXNO
+        CI
+        46LkPR9SVQL7gkuGA73DmFiEAWW4y13Dkd+juOuSnokz3KYHxdFpwi/lD65/eQc=
+  recorded_at: 2025-09-19 12:04:27
+- request:
+    method: POST
+    uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
+    body:
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2015-09-07","end_date":"2015-09-08","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"count":true}'
+  response:
+    status: 201
+    headers:
+      date: Fri, 19 Sep 2025 12:04:27 GMT
+      server: Apache/2.4.58 (Ubuntu)
+      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
+        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
+        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
+      cross-origin-opener-policy: same-origin
+      cache-control: max-age=300, public
+      x-ocpu-session: x0c8ff65e0dedc1
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0c8ff65e0dedc1/
+      access-control-allow-origin: '*'
+      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
+      access-control-allow-headers: '*'
+      access-control-allow-credentials: 'true'
+      x-ocpu-r: R version 4.5.0 (2025-04-11)
+      x-ocpu-locale: C.UTF-8
+      x-ocpu-time: 2025-09-19 12:04:29 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -150,31 +287,31 @@ http_interactions:
             "count": 4
           }
         ]
-  recorded_at: 2025-09-10 14:51:54
+  recorded_at: 2025-09-19 12:04:29
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":"2015-09-07","end_date":"2015-09-08","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2015-09-07","end_date":"2015-09-08","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:54 GMT
+      date: Fri, 19 Sep 2025 12:04:29 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x008b1304b05359
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x008b1304b05359/
+      x-ocpu-session: x053a65050273d1
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x053a65050273d1/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:56 UTC
+      x-ocpu-time: 2025-09-19 12:04:31 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -182,25 +319,25 @@ http_interactions:
       content-length: '138'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x008b1304b05359/R/.val
-        /ocpu/tmp/x008b1304b05359/R/credentials
-        /ocpu/tmp/x008b1304b05359/R/get_acoustic_detections_page
-        /ocpu/tmp/x008b1304b05359/stdout
-        /ocpu/tmp/x008b1304b05359/source
-        /ocpu/tmp/x008b1304b05359/console
-        /ocpu/tmp/x008b1304b05359/info
-        /ocpu/tmp/x008b1304b05359/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:51:56
+        /ocpu/tmp/x053a65050273d1/R/.val
+        /ocpu/tmp/x053a65050273d1/R/credentials
+        /ocpu/tmp/x053a65050273d1/R/get_acoustic_detections_page
+        /ocpu/tmp/x053a65050273d1/stdout
+        /ocpu/tmp/x053a65050273d1/source
+        /ocpu/tmp/x053a65050273d1/console
+        /ocpu/tmp/x053a65050273d1/info
+        /ocpu/tmp/x053a65050273d1/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:04:31
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x008b1304b05359/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x053a65050273d1/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:51:56 GMT
+      date: Fri, 19 Sep 2025 12:04:31 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -214,7 +351,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:57 UTC
+      x-ocpu-time: 2025-09-19 12:04:31 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -247,144 +384,7 @@ http_interactions:
         Z8EpTVEqMshihKPksF1X7GMXZlQYr54zsPB7o3hRMl+KAPeJG8aRIiz0ufkXzAwhO+FXNO
         CI
         46LkPR9SVQL7gkuGA73DmFiEAWW4y13Dkd+juOuSnokz3KYHxdFpwi/lD65/eQc=
-  recorded_at: 2025-09-10 14:51:57
-- request:
-    method: POST
-    uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
-    body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2015-09-07","end_date":"2015-09-08","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"count":true}'
-  response:
-    status: 201
-    headers:
-      date: Wed, 10 Sep 2025 14:51:57 GMT
-      server: Apache/2.4.58 (Ubuntu)
-      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
-        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
-        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
-      cross-origin-opener-policy: same-origin
-      cache-control: max-age=300, public
-      x-ocpu-session: x0df0718f1f0b37
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0df0718f1f0b37/
-      access-control-allow-origin: '*'
-      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
-      access-control-allow-headers: '*'
-      access-control-allow-credentials: 'true'
-      x-ocpu-r: R version 4.5.0 (2025-04-11)
-      x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:59 UTC
-      x-ocpu-version: 2.2.14
-      x-ocpu-server: rApache
-      vary: Accept-Encoding
-      content-encoding: gzip
-      content-length: '44'
-      content-type: application/json
-      access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
-    body:
-      string: |
-        [
-          {
-            "count": 4
-          }
-        ]
-  recorded_at: 2025-09-10 14:51:59
-- request:
-    method: POST
-    uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
-    body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":"2015-09-07","end_date":"2015-09-08","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
-  response:
-    status: 201
-    headers:
-      date: Wed, 10 Sep 2025 14:51:59 GMT
-      server: Apache/2.4.58 (Ubuntu)
-      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
-        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
-        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
-      cross-origin-opener-policy: same-origin
-      cache-control: max-age=300, public
-      x-ocpu-session: x0b747587dce9bb
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0b747587dce9bb/
-      access-control-allow-origin: '*'
-      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
-      access-control-allow-headers: '*'
-      access-control-allow-credentials: 'true'
-      x-ocpu-r: R version 4.5.0 (2025-04-11)
-      x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:01 UTC
-      x-ocpu-version: 2.2.14
-      x-ocpu-server: rApache
-      vary: Accept-Encoding
-      content-encoding: gzip
-      content-length: '137'
-      content-type: text/plain; charset=utf-8
-      access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
-    body:
-      string: |
-        /ocpu/tmp/x0b747587dce9bb/R/.val
-        /ocpu/tmp/x0b747587dce9bb/R/credentials
-        /ocpu/tmp/x0b747587dce9bb/R/get_acoustic_detections_page
-        /ocpu/tmp/x0b747587dce9bb/stdout
-        /ocpu/tmp/x0b747587dce9bb/source
-        /ocpu/tmp/x0b747587dce9bb/console
-        /ocpu/tmp/x0b747587dce9bb/info
-        /ocpu/tmp/x0b747587dce9bb/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:52:01
-- request:
-    method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0b747587dce9bb/R/.val/rds
-  response:
-    status: 200
-    headers:
-      date: Wed, 10 Sep 2025 14:52:01 GMT
-      server: Apache/2.4.58 (Ubuntu)
-      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
-        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
-        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
-      cross-origin-opener-policy: same-origin
-      cache-control: max-age=86400, public
-      content-disposition: attachment;filename=.val.rds
-      access-control-allow-origin: '*'
-      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
-      access-control-allow-headers: '*'
-      access-control-allow-credentials: 'true'
-      x-ocpu-r: R version 4.5.0 (2025-04-11)
-      x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:02 UTC
-      x-ocpu-version: 2.2.14
-      x-ocpu-server: rApache
-      vary: Accept-Encoding
-      content-encoding: gzip
-      content-length: '653'
-      content-type: application/r-rds
-      access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
-    body:
-      raw_gzip: |-
-        eJytVTFvEzEUdpqUkDZtGrVdmNiYEuWuTdJsqSqBKiRAbQrdLNfnBMPduT37Ai0DSAzdGNiY
-        QPwAVia
-        kbgwMLCABv4Id1PKcnK+5E0W0yknvnt/n5+/5vfPzbU8hhLIoNwlvEIQmtzrXKytg
-        zYOxADIDksuo/K
-        vM/tE3kO8gP2B+VuOrX58cPn6GEOjnGtDabg/1pyPNl5uAVwblUEGTU5dI
-        CYM5kIkIzN+5vbm+TVVkX
-        hqYKr1SHQifRSsNmN3qrIE6juCcIbSsptVcsc5nJjlmVxutitWo
-        WRW7UV+qjwFN8k/ZNWsZO8xjwQWR
-        6MtANfaSksxjk7thEMqrPZf4XI4BTeVxwJik95nrsAsi
-        Sb7puxv2vYpl2XarnoTsZtNq/SeU5MxKOND
-        DYQ6G5MwxJKvH7fWXneLHF69BL699eXgtrWO/
-        8sb748vvfrXLt24efvicTWvj9/SnboT827N0vF2ECi
-        fw/EOPm29whKB/0aikyndFVxYPPwmG
-        A9io2fYStqpU9pMeg9obD3uMHufMB+6QNyA3TkVfJZmTiCdrL
-        hq142Knaw4JWOZ0OkSRajcg
-        HkvdQoVAPKr6gMso1oSuF4T+nb6ujJMOuBCBRYcpRhUXPuaOYYRYDCvu
-        mdYoK9LDkgWcuNgP
-        vZ2490uEilAqTrH2iAnmoSk98N0NxAMgx1TEXVaIpmLfkqSc+Yp3gURvMIIXY+a
-        /kEwHjDLe
-        Z8EpTVEqMshihKPksF1X7GMXZlQYr54zsPB7o3hRMl+KAPeJG8aRIiz0ufkXzAwhO+FXNO
-        CI
-        46LkPR9SVQL7gkuGA73DmFiEAWW4y13Dkd+juOuSnokz3KYHxdFpwi/lD65/eQc=
-  recorded_at: 2025-09-10 14:52:02
+  recorded_at: 2025-09-19 12:04:31
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -393,22 +393,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:52:02 GMT
+      date: Fri, 19 Sep 2025 12:04:31 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0bc26f6c9ffb14
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0bc26f6c9ffb14/
+      x-ocpu-session: x0999ebcd181eb0
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0999ebcd181eb0/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:04 UTC
+      x-ocpu-time: 2025-09-19 12:04:33 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -424,31 +424,31 @@ http_interactions:
             "count": 4
           }
         ]
-  recorded_at: 2025-09-10 14:52:04
+  recorded_at: 2025-09-19 12:04:33
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":"2015-09-07","end_date":"2015-09-08","acoustic_tag_id":null,"animal_project_code":"2014_DEMER","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2015-09-07","end_date":"2015-09-08","acoustic_tag_id":null,"animal_project_code":"2014_DEMER","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:52:05 GMT
+      date: Fri, 19 Sep 2025 12:04:33 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x093ea84d9fb33e
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x093ea84d9fb33e/
+      x-ocpu-session: x069b28568aecc3
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x069b28568aecc3/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:07 UTC
+      x-ocpu-time: 2025-09-19 12:04:34 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -456,25 +456,25 @@ http_interactions:
       content-length: '137'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x093ea84d9fb33e/R/.val
-        /ocpu/tmp/x093ea84d9fb33e/R/credentials
-        /ocpu/tmp/x093ea84d9fb33e/R/get_acoustic_detections_page
-        /ocpu/tmp/x093ea84d9fb33e/stdout
-        /ocpu/tmp/x093ea84d9fb33e/source
-        /ocpu/tmp/x093ea84d9fb33e/console
-        /ocpu/tmp/x093ea84d9fb33e/info
-        /ocpu/tmp/x093ea84d9fb33e/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:52:07
+        /ocpu/tmp/x069b28568aecc3/R/.val
+        /ocpu/tmp/x069b28568aecc3/R/credentials
+        /ocpu/tmp/x069b28568aecc3/R/get_acoustic_detections_page
+        /ocpu/tmp/x069b28568aecc3/stdout
+        /ocpu/tmp/x069b28568aecc3/source
+        /ocpu/tmp/x069b28568aecc3/console
+        /ocpu/tmp/x069b28568aecc3/info
+        /ocpu/tmp/x069b28568aecc3/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:04:35
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x093ea84d9fb33e/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x069b28568aecc3/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:52:07 GMT
+      date: Fri, 19 Sep 2025 12:04:35 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -488,7 +488,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:08 UTC
+      x-ocpu-time: 2025-09-19 12:04:35 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -521,7 +521,7 @@ http_interactions:
         Z8EpTVEqMshihKPksF1X7GMXZlQYr54zsPB7o3hRMl+KAPeJG8aRIiz0ufkXzAwhO+FXNO
         CI
         46LkPR9SVQL7gkuGA73DmFiEAWW4y13Dkd+juOuSnokz3KYHxdFpwi/lD65/eQc=
-  recorded_at: 2025-09-10 14:52:08
+  recorded_at: 2025-09-19 12:04:35
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -530,22 +530,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:52:08 GMT
+      date: Fri, 19 Sep 2025 12:04:35 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0ea57dd3fde214
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0ea57dd3fde214/
+      x-ocpu-session: x04b64da4546d6c
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x04b64da4546d6c/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:10 UTC
+      x-ocpu-time: 2025-09-19 12:04:37 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -553,7 +553,7 @@ http_interactions:
       content-length: '47'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
         [
@@ -561,31 +561,31 @@ http_interactions:
             "count": 2196
           }
         ]
-  recorded_at: 2025-09-10 14:52:10
+  recorded_at: 2025-09-19 12:04:37
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":"2015-04-21","end_date":"2015-04-26","acoustic_tag_id":null,"animal_project_code":["2014_demer","2015_dijle"],"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2015-04-21","end_date":"2015-04-26","acoustic_tag_id":null,"animal_project_code":["2014_demer","2015_dijle"],"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:52:10 GMT
+      date: Fri, 19 Sep 2025 12:04:37 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x094b4aa2b93fab
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x094b4aa2b93fab/
+      x-ocpu-session: x00d31412d228e2
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x00d31412d228e2/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:12 UTC
+      x-ocpu-time: 2025-09-19 12:04:39 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -596,23 +596,23 @@ http_interactions:
       set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
-        /ocpu/tmp/x094b4aa2b93fab/R/.val
-        /ocpu/tmp/x094b4aa2b93fab/R/animal_project_code
-        /ocpu/tmp/x094b4aa2b93fab/R/credentials
-        /ocpu/tmp/x094b4aa2b93fab/R/get_acoustic_detections_page
-        /ocpu/tmp/x094b4aa2b93fab/stdout
-        /ocpu/tmp/x094b4aa2b93fab/source
-        /ocpu/tmp/x094b4aa2b93fab/console
-        /ocpu/tmp/x094b4aa2b93fab/info
-        /ocpu/tmp/x094b4aa2b93fab/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:52:12
+        /ocpu/tmp/x00d31412d228e2/R/.val
+        /ocpu/tmp/x00d31412d228e2/R/animal_project_code
+        /ocpu/tmp/x00d31412d228e2/R/credentials
+        /ocpu/tmp/x00d31412d228e2/R/get_acoustic_detections_page
+        /ocpu/tmp/x00d31412d228e2/stdout
+        /ocpu/tmp/x00d31412d228e2/source
+        /ocpu/tmp/x00d31412d228e2/console
+        /ocpu/tmp/x00d31412d228e2/info
+        /ocpu/tmp/x00d31412d228e2/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:04:39
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x094b4aa2b93fab/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x00d31412d228e2/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:52:12 GMT
+      date: Fri, 19 Sep 2025 12:04:39 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -626,7 +626,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:13 UTC
+      x-ocpu-time: 2025-09-19 12:04:39 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -634,7 +634,7 @@ http_interactions:
       content-length: '16358'
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       raw_gzip: |-
         eJztnQm8F1X9/i/uu5iaVm7lkpaaIKCWmbsofL/ABVwqRS6gUgjKzHBX3K1MbVEsyzujIq4J
@@ -1217,5 +1217,5 @@ http_interactions:
         UeNBvQYO6h/16zV48Tv8+MCDksF9+vU6o/
         +AJcfY+Nw+vc4Y0PvMJa8T3ubZfDmLP2ZZ2Yf/
         D6xyBhs=
-  recorded_at: 2025-09-10 14:52:13
+  recorded_at: 2025-09-19 12:04:40
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_columns.yml
+++ b/tests/fixtures/detections_columns.yml
@@ -3,52 +3,52 @@ http_interactions:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100,"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:50:18 GMT
+      date: Fri, 19 Sep 2025 12:03:04 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0df84f9d340786
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0df84f9d340786/
+      x-ocpu-session: x0c79efe2d6c86f
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0c79efe2d6c86f/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:21 UTC
+      x-ocpu-time: 2025-09-19 12:03:07 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '138'
+      content-length: '136'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x0df84f9d340786/R/.val
-        /ocpu/tmp/x0df84f9d340786/R/credentials
-        /ocpu/tmp/x0df84f9d340786/R/get_acoustic_detections_page
-        /ocpu/tmp/x0df84f9d340786/stdout
-        /ocpu/tmp/x0df84f9d340786/source
-        /ocpu/tmp/x0df84f9d340786/console
-        /ocpu/tmp/x0df84f9d340786/info
-        /ocpu/tmp/x0df84f9d340786/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:50:21
+        /ocpu/tmp/x0c79efe2d6c86f/R/.val
+        /ocpu/tmp/x0c79efe2d6c86f/R/credentials
+        /ocpu/tmp/x0c79efe2d6c86f/R/get_acoustic_detections_page
+        /ocpu/tmp/x0c79efe2d6c86f/stdout
+        /ocpu/tmp/x0c79efe2d6c86f/source
+        /ocpu/tmp/x0c79efe2d6c86f/console
+        /ocpu/tmp/x0c79efe2d6c86f/info
+        /ocpu/tmp/x0c79efe2d6c86f/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:03:07
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0df84f9d340786/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x0c79efe2d6c86f/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:50:21 GMT
+      date: Fri, 19 Sep 2025 12:03:07 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -62,7 +62,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:22 UTC
+      x-ocpu-time: 2025-09-19 12:03:07 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -70,7 +70,7 @@ http_interactions:
       content-length: '2516'
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       raw_gzip: |-
         eJztXAlsFOcVnsVXfO5im4amGDvuQQl18F7etYHWbiMEiUgwNpdKu1qvx2bKetfew1Cn2A5N
@@ -162,5 +162,5 @@ http_interactions:
         Or3+qBCJcNEAw3+3az5H2eLs8nhSZDgnzLQGoNRI0BMIMmHaE2IzFBwHoyEfLX6Hy+rweVr8
         3l
         Y+DpdmGzSHLZOiPv8f7oS1bg==
-  recorded_at: 2025-09-10 14:50:22
+  recorded_at: 2025-09-19 12:03:07
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_dates.yml
+++ b/tests/fixtures/detections_dates.yml
@@ -7,22 +7,22 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:50:24 GMT
+      date: Fri, 19 Sep 2025 12:03:09 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x041035080312a1
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x041035080312a1/
+      x-ocpu-session: x038ff2f972ef65
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x038ff2f972ef65/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:26 UTC
+      x-ocpu-time: 2025-09-19 12:03:10 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -46,7 +46,7 @@ http_interactions:
         xg+8Dx1/pRy1fcpaOIcugamwqMm3nUDVjj5Y8k3LP0
         2vNbaeWjS/OI7H3D+n4Jtu+3bOu48O
         +Ognuj0ER2a6GsA3kC0aBA==
-  recorded_at: 2025-09-10 14:50:26
+  recorded_at: 2025-09-19 12:03:10
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -55,22 +55,22 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:50:26 GMT
+      date: Fri, 19 Sep 2025 12:03:10 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0fb11504f5b1ca
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0fb11504f5b1ca/
+      x-ocpu-session: x05ad015c7abb4e
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x05ad015c7abb4e/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:27 UTC
+      x-ocpu-time: 2025-09-19 12:03:11 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -94,7 +94,7 @@ http_interactions:
         pdywI2j9Q2Fs0yOvmDFoYpgxjdK6lmMom7F7JN1F/g
         m9ldgwJat/IY5G1D0lz032uS358MEB
         7f+07g/BWDXbDuATPNsXHw==
-  recorded_at: 2025-09-10 14:50:27
+  recorded_at: 2025-09-19 12:03:11
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -103,22 +103,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:50:27 GMT
+      date: Fri, 19 Sep 2025 12:03:11 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x09899b32d07d8a
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x09899b32d07d8a/
+      x-ocpu-session: x0016d10a7edc2a
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0016d10a7edc2a/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:30 UTC
+      x-ocpu-time: 2025-09-19 12:03:14 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -134,57 +134,57 @@ http_interactions:
             "count": 1696
           }
         ]
-  recorded_at: 2025-09-10 14:50:30
+  recorded_at: 2025-09-19 12:03:14
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":"2017","end_date":null,"acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2017","end_date":null,"acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:50:30 GMT
+      date: Fri, 19 Sep 2025 12:03:14 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x00e8d40acb6a52
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x00e8d40acb6a52/
+      x-ocpu-session: x065f276210df9b
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x065f276210df9b/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:33 UTC
+      x-ocpu-time: 2025-09-19 12:03:16 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '136'
+      content-length: '138'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
-        /ocpu/tmp/x00e8d40acb6a52/R/.val
-        /ocpu/tmp/x00e8d40acb6a52/R/credentials
-        /ocpu/tmp/x00e8d40acb6a52/R/get_acoustic_detections_page
-        /ocpu/tmp/x00e8d40acb6a52/stdout
-        /ocpu/tmp/x00e8d40acb6a52/source
-        /ocpu/tmp/x00e8d40acb6a52/console
-        /ocpu/tmp/x00e8d40acb6a52/info
-        /ocpu/tmp/x00e8d40acb6a52/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:50:33
+        /ocpu/tmp/x065f276210df9b/R/.val
+        /ocpu/tmp/x065f276210df9b/R/credentials
+        /ocpu/tmp/x065f276210df9b/R/get_acoustic_detections_page
+        /ocpu/tmp/x065f276210df9b/stdout
+        /ocpu/tmp/x065f276210df9b/source
+        /ocpu/tmp/x065f276210df9b/console
+        /ocpu/tmp/x065f276210df9b/info
+        /ocpu/tmp/x065f276210df9b/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:03:16
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x00e8d40acb6a52/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x065f276210df9b/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:50:33 GMT
+      date: Fri, 19 Sep 2025 12:03:16 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -198,7 +198,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:34 UTC
+      x-ocpu-time: 2025-09-19 12:03:17 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -206,7 +206,7 @@ http_interactions:
       content-length: '13041'
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       raw_gzip: |-
         eJztnQd8FWX6/a8EUVQExIK+Y6OLoiQECL0TRXoLIBAChBA6JBSxELpg5BoVgRC9k6B0JAME
@@ -671,7 +671,7 @@ http_interactions:
         cUx6plnlaMX9qO+4g+Y/NZ6UkZ42BruaOTZ5zNj0jNTkCSWv8PsNj504YUhq8rD0UQe3cdT4
         IcnDRqW
         kHfw5fJmj8eaU7GYo9O3/A6EoFIg=
-  recorded_at: 2025-09-10 14:50:34
+  recorded_at: 2025-09-19 12:03:17
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -680,22 +680,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:50:34 GMT
+      date: Fri, 19 Sep 2025 12:03:17 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x024dbc3ebf9a96
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x024dbc3ebf9a96/
+      x-ocpu-session: x0385bcf76e6003
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0385bcf76e6003/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:37 UTC
+      x-ocpu-time: 2025-09-19 12:03:20 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -711,31 +711,31 @@ http_interactions:
             "count": 7852
           }
         ]
-  recorded_at: 2025-09-10 14:50:37
+  recorded_at: 2025-09-19 12:03:20
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":"2015-04","end_date":null,"acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2015-04","end_date":null,"acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:50:37 GMT
+      date: Fri, 19 Sep 2025 12:03:20 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x06597bfac27aa0
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x06597bfac27aa0/
+      x-ocpu-session: x0969952f9f360d
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0969952f9f360d/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:40 UTC
+      x-ocpu-time: 2025-09-19 12:03:23 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -743,25 +743,25 @@ http_interactions:
       content-length: '138'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x06597bfac27aa0/R/.val
-        /ocpu/tmp/x06597bfac27aa0/R/credentials
-        /ocpu/tmp/x06597bfac27aa0/R/get_acoustic_detections_page
-        /ocpu/tmp/x06597bfac27aa0/stdout
-        /ocpu/tmp/x06597bfac27aa0/source
-        /ocpu/tmp/x06597bfac27aa0/console
-        /ocpu/tmp/x06597bfac27aa0/info
-        /ocpu/tmp/x06597bfac27aa0/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:50:40
+        /ocpu/tmp/x0969952f9f360d/R/.val
+        /ocpu/tmp/x0969952f9f360d/R/credentials
+        /ocpu/tmp/x0969952f9f360d/R/get_acoustic_detections_page
+        /ocpu/tmp/x0969952f9f360d/stdout
+        /ocpu/tmp/x0969952f9f360d/source
+        /ocpu/tmp/x0969952f9f360d/console
+        /ocpu/tmp/x0969952f9f360d/info
+        /ocpu/tmp/x0969952f9f360d/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:03:23
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x06597bfac27aa0/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x0969952f9f360d/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:50:40 GMT
+      date: Fri, 19 Sep 2025 12:03:23 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -775,7 +775,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:41 UTC
+      x-ocpu-time: 2025-09-19 12:03:24 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -2620,7 +2620,7 @@ http_interactions:
         /kNum2Xy74I7102eNK3wo86cPnba9Ml1tWNntH+Hb9/w9FkzxteOnTh56rLb2PLc8W
         MnTh03
         adm/E9/m2YU7p/3HzGT+9v9Y1xvn
-  recorded_at: 2025-09-10 14:50:41
+  recorded_at: 2025-09-19 12:03:24
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -2629,22 +2629,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:50:41 GMT
+      date: Fri, 19 Sep 2025 12:03:24 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0d726eba83933c
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0d726eba83933c/
+      x-ocpu-session: x00bae483813c47
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x00bae483813c47/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:44 UTC
+      x-ocpu-time: 2025-09-19 12:03:27 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -2660,31 +2660,31 @@ http_interactions:
             "count": 7462
           }
         ]
-  recorded_at: 2025-09-10 14:50:45
+  recorded_at: 2025-09-19 12:03:27
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":"2015-04-24","end_date":null,"acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2015-04-24","end_date":null,"acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:50:45 GMT
+      date: Fri, 19 Sep 2025 12:03:27 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0d8279f563a5a2
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0d8279f563a5a2/
+      x-ocpu-session: x0c7658edb2f8c9
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0c7658edb2f8c9/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:48 UTC
+      x-ocpu-time: 2025-09-19 12:03:30 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -2695,22 +2695,22 @@ http_interactions:
       set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x0d8279f563a5a2/R/.val
-        /ocpu/tmp/x0d8279f563a5a2/R/credentials
-        /ocpu/tmp/x0d8279f563a5a2/R/get_acoustic_detections_page
-        /ocpu/tmp/x0d8279f563a5a2/stdout
-        /ocpu/tmp/x0d8279f563a5a2/source
-        /ocpu/tmp/x0d8279f563a5a2/console
-        /ocpu/tmp/x0d8279f563a5a2/info
-        /ocpu/tmp/x0d8279f563a5a2/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:50:48
+        /ocpu/tmp/x0c7658edb2f8c9/R/.val
+        /ocpu/tmp/x0c7658edb2f8c9/R/credentials
+        /ocpu/tmp/x0c7658edb2f8c9/R/get_acoustic_detections_page
+        /ocpu/tmp/x0c7658edb2f8c9/stdout
+        /ocpu/tmp/x0c7658edb2f8c9/source
+        /ocpu/tmp/x0c7658edb2f8c9/console
+        /ocpu/tmp/x0c7658edb2f8c9/info
+        /ocpu/tmp/x0c7658edb2f8c9/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:03:30
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0d8279f563a5a2/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x0c7658edb2f8c9/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:50:48 GMT
+      date: Fri, 19 Sep 2025 12:03:30 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -2724,14 +2724,14 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:49 UTC
+      x-ocpu-time: 2025-09-19 12:03:30 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       raw_gzip: |-
         eJws3XmgbXOhwPF77kXhhkqmtTn7nlPOmtciMmWsJJnHa56jkHkeU24lzhqcckM4QpN09y3N
@@ -4470,7 +4470,7 @@ http_interactions:
         UD+3qWrBh8V/tXdq5Y2dPX3dk79C/c+IZXruld2N25uGfZhrex
         x+qFnYuXdS3Z8PfEP3P54Adn6N0sF
         J76/yHyt48=
-  recorded_at: 2025-09-10 14:50:49
+  recorded_at: 2025-09-19 12:03:30
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -4479,22 +4479,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:50:49 GMT
+      date: Fri, 19 Sep 2025 12:03:31 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x097d20713c9393
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x097d20713c9393/
+      x-ocpu-session: x07703ff60b1315
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x07703ff60b1315/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:52 UTC
+      x-ocpu-time: 2025-09-19 12:03:33 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -4502,7 +4502,7 @@ http_interactions:
       content-length: '48'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
         [
@@ -4510,31 +4510,31 @@ http_interactions:
             "count": 15519
           }
         ]
-  recorded_at: 2025-09-10 14:50:52
+  recorded_at: 2025-09-19 12:03:33
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":"2016","acoustic_tag_id":null,"animal_project_code":"2015_fint","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":"2016","acoustic_tag_id":null,"animal_project_code":"2015_fint","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:50:52 GMT
+      date: Fri, 19 Sep 2025 12:03:33 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x05286ada95209c
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x05286ada95209c/
+      x-ocpu-session: x082de22005c8c6
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x082de22005c8c6/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:56 UTC
+      x-ocpu-time: 2025-09-19 12:03:37 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -4545,22 +4545,22 @@ http_interactions:
       set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x05286ada95209c/R/.val
-        /ocpu/tmp/x05286ada95209c/R/credentials
-        /ocpu/tmp/x05286ada95209c/R/get_acoustic_detections_page
-        /ocpu/tmp/x05286ada95209c/stdout
-        /ocpu/tmp/x05286ada95209c/source
-        /ocpu/tmp/x05286ada95209c/console
-        /ocpu/tmp/x05286ada95209c/info
-        /ocpu/tmp/x05286ada95209c/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:50:56
+        /ocpu/tmp/x082de22005c8c6/R/.val
+        /ocpu/tmp/x082de22005c8c6/R/credentials
+        /ocpu/tmp/x082de22005c8c6/R/get_acoustic_detections_page
+        /ocpu/tmp/x082de22005c8c6/stdout
+        /ocpu/tmp/x082de22005c8c6/source
+        /ocpu/tmp/x082de22005c8c6/console
+        /ocpu/tmp/x082de22005c8c6/info
+        /ocpu/tmp/x082de22005c8c6/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:03:37
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x05286ada95209c/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x082de22005c8c6/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:50:56 GMT
+      date: Fri, 19 Sep 2025 12:03:37 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -4574,7 +4574,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:57 UTC
+      x-ocpu-time: 2025-09-19 12:03:38 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -7943,7 +7943,7 @@ http_interactions:
         TM2rdjft4p7hV26euWej86ZeOLe6ce7M5vrq+e3X8MoLP
         nf/+ZPrq6fPnN19GYe+/+Tq6bNr
         9+x+O5dfzXs775ztNzNJ/u3fAVMQJas=
-  recorded_at: 2025-09-10 14:50:57
+  recorded_at: 2025-09-19 12:03:38
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -7952,22 +7952,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:50:57 GMT
+      date: Fri, 19 Sep 2025 12:03:38 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x08d1ac4a8b2b03
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x08d1ac4a8b2b03/
+      x-ocpu-session: x02c62d3c7e4bd9
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x02c62d3c7e4bd9/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:00 UTC
+      x-ocpu-time: 2025-09-19 12:03:41 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -7975,7 +7975,7 @@ http_interactions:
       content-length: '47'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
         [
@@ -7983,57 +7983,57 @@ http_interactions:
             "count": 3484
           }
         ]
-  recorded_at: 2025-09-10 14:51:00
+  recorded_at: 2025-09-19 12:03:41
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":"2015-05","acoustic_tag_id":null,"animal_project_code":"2015_fint","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":"2015-05","acoustic_tag_id":null,"animal_project_code":"2015_fint","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:00 GMT
+      date: Fri, 19 Sep 2025 12:03:41 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0a75839a522702
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0a75839a522702/
+      x-ocpu-session: x0704065454f048
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0704065454f048/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:04 UTC
+      x-ocpu-time: 2025-09-19 12:03:44 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '138'
+      content-length: '137'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
-        /ocpu/tmp/x0a75839a522702/R/.val
-        /ocpu/tmp/x0a75839a522702/R/credentials
-        /ocpu/tmp/x0a75839a522702/R/get_acoustic_detections_page
-        /ocpu/tmp/x0a75839a522702/stdout
-        /ocpu/tmp/x0a75839a522702/source
-        /ocpu/tmp/x0a75839a522702/console
-        /ocpu/tmp/x0a75839a522702/info
-        /ocpu/tmp/x0a75839a522702/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:51:04
+        /ocpu/tmp/x0704065454f048/R/.val
+        /ocpu/tmp/x0704065454f048/R/credentials
+        /ocpu/tmp/x0704065454f048/R/get_acoustic_detections_page
+        /ocpu/tmp/x0704065454f048/stdout
+        /ocpu/tmp/x0704065454f048/source
+        /ocpu/tmp/x0704065454f048/console
+        /ocpu/tmp/x0704065454f048/info
+        /ocpu/tmp/x0704065454f048/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:03:44
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0a75839a522702/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x0704065454f048/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:51:04 GMT
+      date: Fri, 19 Sep 2025 12:03:44 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -8047,7 +8047,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:05 UTC
+      x-ocpu-time: 2025-09-19 12:03:45 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -8055,7 +8055,7 @@ http_interactions:
       content-length: '24149'
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       raw_gzip: |-
         eJzsnQeYFGXWtmcAFVFgXNaEumZBV7qqCIq75jWv9HSbwEhmVJBsVjIqOZvtGgkN9Ez3AGal
@@ -8897,7 +8897,7 @@ http_interactions:
         1K+oPnhFePlIYLEbfank4WxwujOSzpcpX2Ljx8GipL58dKAzV77Hs
         zr7swFBusP55ql/mtugfTuXbDI
         L3/gvKgEJI
-  recorded_at: 2025-09-10 14:51:05
+  recorded_at: 2025-09-19 12:03:45
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -8906,22 +8906,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:05 GMT
+      date: Fri, 19 Sep 2025 12:03:45 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0b09655413725f
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0b09655413725f/
+      x-ocpu-session: x00259467dc9034
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x00259467dc9034/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:08 UTC
+      x-ocpu-time: 2025-09-19 12:03:48 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -8929,7 +8929,7 @@ http_interactions:
       content-length: '46'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
         [
@@ -8937,31 +8937,31 @@ http_interactions:
             "count": 903
           }
         ]
-  recorded_at: 2025-09-10 14:51:09
+  recorded_at: 2025-09-19 12:03:48
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":"2014-04-25","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":"2014-04-25","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:09 GMT
+      date: Fri, 19 Sep 2025 12:03:48 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0de316bc8edc4a
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0de316bc8edc4a/
+      x-ocpu-session: x07c121a8aab38e
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x07c121a8aab38e/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:12 UTC
+      x-ocpu-time: 2025-09-19 12:03:51 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -8972,22 +8972,22 @@ http_interactions:
       set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x0de316bc8edc4a/R/.val
-        /ocpu/tmp/x0de316bc8edc4a/R/credentials
-        /ocpu/tmp/x0de316bc8edc4a/R/get_acoustic_detections_page
-        /ocpu/tmp/x0de316bc8edc4a/stdout
-        /ocpu/tmp/x0de316bc8edc4a/source
-        /ocpu/tmp/x0de316bc8edc4a/console
-        /ocpu/tmp/x0de316bc8edc4a/info
-        /ocpu/tmp/x0de316bc8edc4a/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:51:12
+        /ocpu/tmp/x07c121a8aab38e/R/.val
+        /ocpu/tmp/x07c121a8aab38e/R/credentials
+        /ocpu/tmp/x07c121a8aab38e/R/get_acoustic_detections_page
+        /ocpu/tmp/x07c121a8aab38e/stdout
+        /ocpu/tmp/x07c121a8aab38e/source
+        /ocpu/tmp/x07c121a8aab38e/console
+        /ocpu/tmp/x07c121a8aab38e/info
+        /ocpu/tmp/x07c121a8aab38e/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:03:51
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0de316bc8edc4a/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x07c121a8aab38e/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:51:12 GMT
+      date: Fri, 19 Sep 2025 12:03:51 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -9001,7 +9001,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:13 UTC
+      x-ocpu-time: 2025-09-19 12:03:52 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -9346,7 +9346,7 @@ http_interactions:
         Q1VZQUaeVayOTtQp2GVdRVilNtabKWVlVMc7jrD45wlMNV42vdntq/wq5xXVu
         Z+loV5ncjxjmGEk4J6
         epUv32/0Oj7y4=
-  recorded_at: 2025-09-10 14:51:13
+  recorded_at: 2025-09-19 12:03:52
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -9355,22 +9355,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:13 GMT
+      date: Fri, 19 Sep 2025 12:03:52 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0f0c0c8eb38b70
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0f0c0c8eb38b70/
+      x-ocpu-session: x0f2ced5df6871b
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0f2ced5df6871b/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:16 UTC
+      x-ocpu-time: 2025-09-19 12:03:55 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -9378,7 +9378,7 @@ http_interactions:
       content-length: '47'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
         [
@@ -9386,31 +9386,31 @@ http_interactions:
             "count": 3623
           }
         ]
-  recorded_at: 2025-09-10 14:51:16
+  recorded_at: 2025-09-19 12:03:55
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":"2016","end_date":"2017","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2016","end_date":"2017","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:16 GMT
+      date: Fri, 19 Sep 2025 12:03:55 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x08c441ae29cc82
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x08c441ae29cc82/
+      x-ocpu-session: x07fe80a013e13f
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x07fe80a013e13f/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:19 UTC
+      x-ocpu-time: 2025-09-19 12:03:58 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -9421,22 +9421,22 @@ http_interactions:
       set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
-        /ocpu/tmp/x08c441ae29cc82/R/.val
-        /ocpu/tmp/x08c441ae29cc82/R/credentials
-        /ocpu/tmp/x08c441ae29cc82/R/get_acoustic_detections_page
-        /ocpu/tmp/x08c441ae29cc82/stdout
-        /ocpu/tmp/x08c441ae29cc82/source
-        /ocpu/tmp/x08c441ae29cc82/console
-        /ocpu/tmp/x08c441ae29cc82/info
-        /ocpu/tmp/x08c441ae29cc82/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:51:19
+        /ocpu/tmp/x07fe80a013e13f/R/.val
+        /ocpu/tmp/x07fe80a013e13f/R/credentials
+        /ocpu/tmp/x07fe80a013e13f/R/get_acoustic_detections_page
+        /ocpu/tmp/x07fe80a013e13f/stdout
+        /ocpu/tmp/x07fe80a013e13f/source
+        /ocpu/tmp/x07fe80a013e13f/console
+        /ocpu/tmp/x07fe80a013e13f/info
+        /ocpu/tmp/x07fe80a013e13f/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:03:59
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x08c441ae29cc82/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x07fe80a013e13f/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:51:19 GMT
+      date: Fri, 19 Sep 2025 12:03:59 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -9450,7 +9450,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:20 UTC
+      x-ocpu-time: 2025-09-19 12:03:59 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -10338,7 +10338,7 @@ http_interactions:
         W8ezL2pzojI+UW/UKpOt38KjH3hianKkVtlSH5v+GCveMVLZMlbdOv3rCb+Z27KvnNYXM0kO
         /T/hWw
         b9
-  recorded_at: 2025-09-10 14:51:20
+  recorded_at: 2025-09-19 12:03:59
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -10347,22 +10347,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:20 GMT
+      date: Fri, 19 Sep 2025 12:03:59 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x03742a11fbb10d
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x03742a11fbb10d/
+      x-ocpu-session: x070c4e6a6309dc
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x070c4e6a6309dc/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:23 UTC
+      x-ocpu-time: 2025-09-19 12:04:01 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -10370,7 +10370,7 @@ http_interactions:
       content-length: '46'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
         [
@@ -10378,57 +10378,57 @@ http_interactions:
             "count": 442
           }
         ]
-  recorded_at: 2025-09-10 14:51:23
+  recorded_at: 2025-09-19 12:04:01
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":"2015-04","end_date":"2015-05","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2015-04","end_date":"2015-05","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:23 GMT
+      date: Fri, 19 Sep 2025 12:04:01 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x001fc25fcced29
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x001fc25fcced29/
+      x-ocpu-session: x041212a492c5de
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x041212a492c5de/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:25 UTC
+      x-ocpu-time: 2025-09-19 12:04:03 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '136'
+      content-length: '137'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
       set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x001fc25fcced29/R/.val
-        /ocpu/tmp/x001fc25fcced29/R/credentials
-        /ocpu/tmp/x001fc25fcced29/R/get_acoustic_detections_page
-        /ocpu/tmp/x001fc25fcced29/stdout
-        /ocpu/tmp/x001fc25fcced29/source
-        /ocpu/tmp/x001fc25fcced29/console
-        /ocpu/tmp/x001fc25fcced29/info
-        /ocpu/tmp/x001fc25fcced29/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:51:25
+        /ocpu/tmp/x041212a492c5de/R/.val
+        /ocpu/tmp/x041212a492c5de/R/credentials
+        /ocpu/tmp/x041212a492c5de/R/get_acoustic_detections_page
+        /ocpu/tmp/x041212a492c5de/stdout
+        /ocpu/tmp/x041212a492c5de/source
+        /ocpu/tmp/x041212a492c5de/console
+        /ocpu/tmp/x041212a492c5de/info
+        /ocpu/tmp/x041212a492c5de/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:04:03
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x001fc25fcced29/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x041212a492c5de/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:51:25 GMT
+      date: Fri, 19 Sep 2025 12:04:04 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -10442,7 +10442,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:26 UTC
+      x-ocpu-time: 2025-09-19 12:04:04 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -10450,7 +10450,7 @@ http_interactions:
       content-length: '3695'
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       raw_gzip: |-
         eJztnXl8VOW9xickYV8vYN2oWgvIbQPJZAEqu4LBIUNCAoIIw8lkCCMh0cwEZFHR20XBwr21
@@ -10584,7 +10584,7 @@ http_interactions:
         0fKelOvYYn4j2DMSLi7FrUbLAqVl4UgoUN58hScGLqsoD4YCM8MlLWO0uTEYmFniFLech
         5c5
         B5PTfJseT+NfASqNx9Y=
-  recorded_at: 2025-09-10 14:51:26
+  recorded_at: 2025-09-19 12:04:04
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -10593,22 +10593,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:26 GMT
+      date: Fri, 19 Sep 2025 12:04:04 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0a495170913d13
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0a495170913d13/
+      x-ocpu-session: x0e20a6b756da70
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0e20a6b756da70/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:29 UTC
+      x-ocpu-time: 2025-09-19 12:04:06 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -10616,7 +10616,7 @@ http_interactions:
       content-length: '44'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
         [
@@ -10624,57 +10624,57 @@ http_interactions:
             "count": 2
           }
         ]
-  recorded_at: 2025-09-10 14:51:29
+  recorded_at: 2025-09-19 12:04:06
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":"2015-04-24","end_date":"2015-04-25","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2015-04-24","end_date":"2015-04-25","acoustic_tag_id":null,"animal_project_code":"2014_demer","scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:29 GMT
+      date: Fri, 19 Sep 2025 12:04:06 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x089c7d380ab4f2
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x089c7d380ab4f2/
+      x-ocpu-session: x0d9b1dcb1b0e19
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0d9b1dcb1b0e19/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:31 UTC
+      x-ocpu-time: 2025-09-19 12:04:08 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '138'
+      content-length: '135'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
       set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
-        /ocpu/tmp/x089c7d380ab4f2/R/.val
-        /ocpu/tmp/x089c7d380ab4f2/R/credentials
-        /ocpu/tmp/x089c7d380ab4f2/R/get_acoustic_detections_page
-        /ocpu/tmp/x089c7d380ab4f2/stdout
-        /ocpu/tmp/x089c7d380ab4f2/source
-        /ocpu/tmp/x089c7d380ab4f2/console
-        /ocpu/tmp/x089c7d380ab4f2/info
-        /ocpu/tmp/x089c7d380ab4f2/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:51:31
+        /ocpu/tmp/x0d9b1dcb1b0e19/R/.val
+        /ocpu/tmp/x0d9b1dcb1b0e19/R/credentials
+        /ocpu/tmp/x0d9b1dcb1b0e19/R/get_acoustic_detections_page
+        /ocpu/tmp/x0d9b1dcb1b0e19/stdout
+        /ocpu/tmp/x0d9b1dcb1b0e19/source
+        /ocpu/tmp/x0d9b1dcb1b0e19/console
+        /ocpu/tmp/x0d9b1dcb1b0e19/info
+        /ocpu/tmp/x0d9b1dcb1b0e19/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:04:08
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x089c7d380ab4f2/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x0d9b1dcb1b0e19/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:51:31 GMT
+      date: Fri, 19 Sep 2025 12:04:08 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -10688,7 +10688,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:32 UTC
+      x-ocpu-time: 2025-09-19 12:04:08 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -10696,7 +10696,7 @@ http_interactions:
       content-length: '582'
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       raw_gzip: |-
         eJyVVDFvEzEUvjQpIe21SVW6MPEHEuUOkrZbKySkLoDaFLpZrs8JRj67tX1BVELwCxj4A0hs
@@ -10719,5 +10719,5 @@ http_interactions:
         GZfPEYcVk+S7Ow6WYlLEfU2FlgpNMU/yTBmWCOY+IWspFJZ4vgMLxC3NJgKOaiQ
         SkmmKlK0w
         F5aJIhSNGXcazXOCxhxPXJ60zBguxx4TvkS/Aa6gCYs=
-  recorded_at: 2025-09-10 14:51:32
+  recorded_at: 2025-09-19 12:04:08
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_error.yml
+++ b/tests/fixtures/detections_error.yml
@@ -7,22 +7,22 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:50:14 GMT
+      date: Fri, 19 Sep 2025 12:03:00 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x04f2492b314f74
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x04f2492b314f74/
+      x-ocpu-session: x05588ea40f83ea
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x05588ea40f83ea/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:15 UTC
+      x-ocpu-time: 2025-09-19 12:03:02 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -46,5 +46,5 @@ http_interactions:
         xg+8Dx1/pRy1fcpaOIcugamwqMm3nUDVjj5Y8k3LP0
         2vNbaeWjS/OI7H3D+n4Jtu+3bOu48O
         +Ognuj0ER2a6GsA3kC0aBA==
-  recorded_at: 2025-09-10 14:50:15
+  recorded_at: 2025-09-19 12:03:02
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_limit.yml
+++ b/tests/fixtures/detections_limit.yml
@@ -3,52 +3,52 @@ http_interactions:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100,"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:50:15 GMT
+      date: Fri, 19 Sep 2025 12:03:02 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0d090227a9dfc8
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0d090227a9dfc8/
+      x-ocpu-session: x01cc9109e4ff0c
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x01cc9109e4ff0c/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:17 UTC
+      x-ocpu-time: 2025-09-19 12:03:03 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '137'
+      content-length: '136'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
       set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x0d090227a9dfc8/R/.val
-        /ocpu/tmp/x0d090227a9dfc8/R/credentials
-        /ocpu/tmp/x0d090227a9dfc8/R/get_acoustic_detections_page
-        /ocpu/tmp/x0d090227a9dfc8/stdout
-        /ocpu/tmp/x0d090227a9dfc8/source
-        /ocpu/tmp/x0d090227a9dfc8/console
-        /ocpu/tmp/x0d090227a9dfc8/info
-        /ocpu/tmp/x0d090227a9dfc8/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:50:17
+        /ocpu/tmp/x01cc9109e4ff0c/R/.val
+        /ocpu/tmp/x01cc9109e4ff0c/R/credentials
+        /ocpu/tmp/x01cc9109e4ff0c/R/get_acoustic_detections_page
+        /ocpu/tmp/x01cc9109e4ff0c/stdout
+        /ocpu/tmp/x01cc9109e4ff0c/source
+        /ocpu/tmp/x01cc9109e4ff0c/console
+        /ocpu/tmp/x01cc9109e4ff0c/info
+        /ocpu/tmp/x01cc9109e4ff0c/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:03:03
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0d090227a9dfc8/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x01cc9109e4ff0c/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:50:17 GMT
+      date: Fri, 19 Sep 2025 12:03:03 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -62,7 +62,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:17 UTC
+      x-ocpu-time: 2025-09-19 12:03:03 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -122,5 +122,5 @@ http_interactions:
         DkaiiTXJXNTQ4x8qnk+pQFJdXjzZo7DY1hsM7KpjKoap25piuVuYaGxGLVVTwnok
         3iNnsaqEI4l/ac2
         nzWzEwXF3U4jufwB0wRR0
-  recorded_at: 2025-09-10 14:50:18
+  recorded_at: 2025-09-19 12:03:03
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_limit_param.yml
+++ b/tests/fixtures/detections_limit_param.yml
@@ -3,52 +3,52 @@ http_interactions:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100,"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:37 GMT
+      date: Fri, 19 Sep 2025 12:07:52 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x03c8bc1c6e5da8
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x03c8bc1c6e5da8/
+      x-ocpu-session: x0517e096f41efc
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0517e096f41efc/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:38 UTC
+      x-ocpu-time: 2025-09-19 12:07:53 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '137'
+      content-length: '138'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x03c8bc1c6e5da8/R/.val
-        /ocpu/tmp/x03c8bc1c6e5da8/R/credentials
-        /ocpu/tmp/x03c8bc1c6e5da8/R/get_acoustic_detections_page
-        /ocpu/tmp/x03c8bc1c6e5da8/stdout
-        /ocpu/tmp/x03c8bc1c6e5da8/source
-        /ocpu/tmp/x03c8bc1c6e5da8/console
-        /ocpu/tmp/x03c8bc1c6e5da8/info
-        /ocpu/tmp/x03c8bc1c6e5da8/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:55:38
+        /ocpu/tmp/x0517e096f41efc/R/.val
+        /ocpu/tmp/x0517e096f41efc/R/credentials
+        /ocpu/tmp/x0517e096f41efc/R/get_acoustic_detections_page
+        /ocpu/tmp/x0517e096f41efc/stdout
+        /ocpu/tmp/x0517e096f41efc/source
+        /ocpu/tmp/x0517e096f41efc/console
+        /ocpu/tmp/x0517e096f41efc/info
+        /ocpu/tmp/x0517e096f41efc/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:07:53
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x03c8bc1c6e5da8/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x0517e096f41efc/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:55:38 GMT
+      date: Fri, 19 Sep 2025 12:07:53 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -62,7 +62,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:39 UTC
+      x-ocpu-time: 2025-09-19 12:07:54 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -122,57 +122,57 @@ http_interactions:
         DkaiiTXJXNTQ4x8qnk+pQFJdXjzZo7DY1hsM7KpjKoap25piuVuYaGxGLVVTwnok
         3iNnsaqEI4l/ac2
         nzWzEwXF3U4jufwB0wRR0
-  recorded_at: 2025-09-10 14:55:39
+  recorded_at: 2025-09-19 12:07:54
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100,"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":"demer","deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":"demer","deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:39 GMT
+      date: Fri, 19 Sep 2025 12:07:54 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x04dcb3527c3550
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x04dcb3527c3550/
+      x-ocpu-session: x0711a7caf8e121
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0711a7caf8e121/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:41 UTC
+      x-ocpu-time: 2025-09-19 12:07:56 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '138'
+      content-length: '136'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
-        /ocpu/tmp/x04dcb3527c3550/R/.val
-        /ocpu/tmp/x04dcb3527c3550/R/credentials
-        /ocpu/tmp/x04dcb3527c3550/R/get_acoustic_detections_page
-        /ocpu/tmp/x04dcb3527c3550/stdout
-        /ocpu/tmp/x04dcb3527c3550/source
-        /ocpu/tmp/x04dcb3527c3550/console
-        /ocpu/tmp/x04dcb3527c3550/info
-        /ocpu/tmp/x04dcb3527c3550/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:55:41
+        /ocpu/tmp/x0711a7caf8e121/R/.val
+        /ocpu/tmp/x0711a7caf8e121/R/credentials
+        /ocpu/tmp/x0711a7caf8e121/R/get_acoustic_detections_page
+        /ocpu/tmp/x0711a7caf8e121/stdout
+        /ocpu/tmp/x0711a7caf8e121/source
+        /ocpu/tmp/x0711a7caf8e121/console
+        /ocpu/tmp/x0711a7caf8e121/info
+        /ocpu/tmp/x0711a7caf8e121/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:07:56
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x04dcb3527c3550/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x0711a7caf8e121/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:55:41 GMT
+      date: Fri, 19 Sep 2025 12:07:56 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -186,7 +186,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:42 UTC
+      x-ocpu-time: 2025-09-19 12:07:57 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -286,5 +286,5 @@ http_interactions:
         B3/o8YMmEhW8Tbw4GGgXywvCdCAcDHl6vP6okAnLogGG/17TQk5kibEr4IUiw3lhpj0ArUaC
         nk
         CQCdOeEFuhEDgYDflo8TtcTrfP0+b3tvN5uDI7YThsmxT1+f8AXOq9cA==
-  recorded_at: 2025-09-10 14:55:42
+  recorded_at: 2025-09-19 12:07:57
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_multiple_parameters.yml
+++ b/tests/fixtures/detections_multiple_parameters.yml
@@ -8,22 +8,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:42 GMT
+      date: Fri, 19 Sep 2025 12:07:57 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0e8f44638f7cdd
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0e8f44638f7cdd/
+      x-ocpu-session: x04acc36a405d1a
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x04acc36a405d1a/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:44 UTC
+      x-ocpu-time: 2025-09-19 12:07:59 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -39,58 +39,58 @@ http_interactions:
             "count": 6
           }
         ]
-  recorded_at: 2025-09-10 14:55:44
+  recorded_at: 2025-09-19 12:07:59
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":"2014-04-24","end_date":"2014-04-25","acoustic_tag_id":"A69-1601-16130","animal_project_code":"2014_demer","scientific_name":"Rutilus
-        rutilus","acoustic_project_code":"demer","deployment_id":null,"receiver_id":"VR2W-124070","station_name":"de-9"}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2014-04-24","end_date":"2014-04-25","acoustic_tag_id":"A69-1601-16130","animal_project_code":"2014_demer","scientific_name":"Rutilus
+        rutilus","acoustic_project_code":"demer","deployment_id":null,"receiver_id":"VR2W-124070","station_name":"de-9","next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:44 GMT
+      date: Fri, 19 Sep 2025 12:07:59 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x023aa34c802559
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x023aa34c802559/
+      x-ocpu-session: x0d4bd3a103cb6b
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0d4bd3a103cb6b/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:46 UTC
+      x-ocpu-time: 2025-09-19 12:08:01 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '138'
+      content-length: '137'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
       set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x023aa34c802559/R/.val
-        /ocpu/tmp/x023aa34c802559/R/credentials
-        /ocpu/tmp/x023aa34c802559/R/get_acoustic_detections_page
-        /ocpu/tmp/x023aa34c802559/stdout
-        /ocpu/tmp/x023aa34c802559/source
-        /ocpu/tmp/x023aa34c802559/console
-        /ocpu/tmp/x023aa34c802559/info
-        /ocpu/tmp/x023aa34c802559/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:55:47
+        /ocpu/tmp/x0d4bd3a103cb6b/R/.val
+        /ocpu/tmp/x0d4bd3a103cb6b/R/credentials
+        /ocpu/tmp/x0d4bd3a103cb6b/R/get_acoustic_detections_page
+        /ocpu/tmp/x0d4bd3a103cb6b/stdout
+        /ocpu/tmp/x0d4bd3a103cb6b/source
+        /ocpu/tmp/x0d4bd3a103cb6b/console
+        /ocpu/tmp/x0d4bd3a103cb6b/info
+        /ocpu/tmp/x0d4bd3a103cb6b/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:08:01
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x023aa34c802559/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x0d4bd3a103cb6b/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:55:47 GMT
+      date: Fri, 19 Sep 2025 12:08:01 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -104,7 +104,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:47 UTC
+      x-ocpu-time: 2025-09-19 12:08:01 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -137,5 +137,5 @@ http_interactions:
         RvGiIEzwEB+5QRRH0ljEqHl0l4ZQNeFXNOCI45qgPQalSo4Zp4LgUGUYE/Mo9Mjoycs/8n
         A3
         cHsmzjDNPmyOKhPe7t+zbtu8
-  recorded_at: 2025-09-10 14:55:47
+  recorded_at: 2025-09-19 12:08:01
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_no_animal.yml
+++ b/tests/fixtures/detections_no_animal.yml
@@ -7,22 +7,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:56:08 GMT
+      date: Fri, 19 Sep 2025 12:08:20 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x00b2ad0306d78b
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x00b2ad0306d78b/
+      x-ocpu-session: x041d895e80b863
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x041d895e80b863/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:56:10 UTC
+      x-ocpu-time: 2025-09-19 12:08:22 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -38,31 +38,31 @@ http_interactions:
             "count": 84
           }
         ]
-  recorded_at: 2025-09-10 14:56:10
+  recorded_at: 2025-09-19 12:08:22
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":null,"acoustic_tag_id":"A180-1702-49684","animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":"A180-1702-49684","animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:56:10 GMT
+      date: Fri, 19 Sep 2025 12:08:22 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x06e9e126e7806a
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x06e9e126e7806a/
+      x-ocpu-session: x06c5a692612afd
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x06c5a692612afd/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:56:11 UTC
+      x-ocpu-time: 2025-09-19 12:08:23 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -73,22 +73,22 @@ http_interactions:
       set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x06e9e126e7806a/R/.val
-        /ocpu/tmp/x06e9e126e7806a/R/credentials
-        /ocpu/tmp/x06e9e126e7806a/R/get_acoustic_detections_page
-        /ocpu/tmp/x06e9e126e7806a/stdout
-        /ocpu/tmp/x06e9e126e7806a/source
-        /ocpu/tmp/x06e9e126e7806a/console
-        /ocpu/tmp/x06e9e126e7806a/info
-        /ocpu/tmp/x06e9e126e7806a/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:56:11
+        /ocpu/tmp/x06c5a692612afd/R/.val
+        /ocpu/tmp/x06c5a692612afd/R/credentials
+        /ocpu/tmp/x06c5a692612afd/R/get_acoustic_detections_page
+        /ocpu/tmp/x06c5a692612afd/stdout
+        /ocpu/tmp/x06c5a692612afd/source
+        /ocpu/tmp/x06c5a692612afd/console
+        /ocpu/tmp/x06c5a692612afd/info
+        /ocpu/tmp/x06c5a692612afd/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:08:23
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x06e9e126e7806a/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x06c5a692612afd/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:56:11 GMT
+      date: Fri, 19 Sep 2025 12:08:23 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -102,7 +102,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:56:12 UTC
+      x-ocpu-time: 2025-09-19 12:08:24 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -110,7 +110,7 @@ http_interactions:
       content-length: '1268'
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       raw_gzip: |-
         eJztnG9sE3UYx2/roBkMBhl7QSIGoxgz2NK7dl1Hhhnhj0FhLls3Ftk4b+113rj25t11iBBc
@@ -158,5 +158,5 @@ http_interactions:
         yMtmDJesRcJS8nIVvnlDsNox+jK4qq6lZizD0VXb28NcYytrJ3Q1ZZh+j+CzCTVlan3+OmI3
         0
         7hxvKspSZN/A8dBtNs=
-  recorded_at: 2025-09-10 14:56:12
+  recorded_at: 2025-09-19 12:08:24
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_no_results.yml
+++ b/tests/fixtures/detections_no_results.yml
@@ -7,22 +7,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:50:22 GMT
+      date: Fri, 19 Sep 2025 12:03:07 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x051b8be116351a
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x051b8be116351a/
+      x-ocpu-session: x0b32c76cb0a2b8
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0b32c76cb0a2b8/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:50:24 UTC
+      x-ocpu-time: 2025-09-19 12:03:09 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -30,7 +30,7 @@ http_interactions:
       content-length: '44'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
         [
@@ -38,5 +38,5 @@ http_interactions:
             "count": 0
           }
         ]
-  recorded_at: 2025-09-10 14:50:24
+  recorded_at: 2025-09-19 12:03:09
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_receiver_id.yml
+++ b/tests/fixtures/detections_receiver_id.yml
@@ -7,22 +7,22 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:55:03 GMT
+      date: Fri, 19 Sep 2025 12:07:21 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0689795eb6ffe1
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0689795eb6ffe1/
+      x-ocpu-session: x0415854409a0a9
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0415854409a0a9/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:04 UTC
+      x-ocpu-time: 2025-09-19 12:07:22 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -52,7 +52,7 @@ http_interactions:
         +X6+DvSm4PTKnHJhUqULKyeNhEiFhZUSMCKyjs6+yfmZra+umTV7bUzFbrrCqyd
         +HVrhFWhk
         EtehJkDnC58XrKAQcb5YytgiPNLhpmsksp2sc5r5Z+XatT8zOSkB
-  recorded_at: 2025-09-10 14:55:04
+  recorded_at: 2025-09-19 12:07:22
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -61,29 +61,29 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:55:04 GMT
+      date: Fri, 19 Sep 2025 12:07:22 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x04e6a6304beafa
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x04e6a6304beafa/
+      x-ocpu-session: x004785a7194aae
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x004785a7194aae/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:05 UTC
+      x-ocpu-time: 2025-09-19 12:07:23 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
       content-length: '608'
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       raw_gzip: |-
         eJyVVN1u2jAUvucprKrSEolkcSAFoqoSUKROq1bEUKsJVYmbuMRq5iDb0F1Ou9gToF3t6XiS
@@ -108,7 +108,7 @@ http_interactions:
         sddaV+y6K7x8plehEV5KjVziKlQEWfnS5xUJmQg7Xyx5YkQ0VmHX1jay7axznPvn6ZqNPx
         Ci
         LtA=
-  recorded_at: 2025-09-10 14:55:05
+  recorded_at: 2025-09-19 12:07:23
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -117,22 +117,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:05 GMT
+      date: Fri, 19 Sep 2025 12:07:23 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0d7b801d88ae1d
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0d7b801d88ae1d/
+      x-ocpu-session: x0880326ffabeae
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0880326ffabeae/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:07 UTC
+      x-ocpu-time: 2025-09-19 12:07:25 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -148,57 +148,57 @@ http_interactions:
             "count": 75687
           }
         ]
-  recorded_at: 2025-09-10 14:55:08
+  recorded_at: 2025-09-19 12:07:25
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":"VR2W-124070","station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":"VR2W-124070","station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:07 GMT
+      date: Fri, 19 Sep 2025 12:07:25 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x04288bbd939adb
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x04288bbd939adb/
+      x-ocpu-session: x0a03132e45009a
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0a03132e45009a/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:10 UTC
+      x-ocpu-time: 2025-09-19 12:07:27 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '138'
+      content-length: '137'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
-        /ocpu/tmp/x04288bbd939adb/R/.val
-        /ocpu/tmp/x04288bbd939adb/R/credentials
-        /ocpu/tmp/x04288bbd939adb/R/get_acoustic_detections_page
-        /ocpu/tmp/x04288bbd939adb/stdout
-        /ocpu/tmp/x04288bbd939adb/source
-        /ocpu/tmp/x04288bbd939adb/console
-        /ocpu/tmp/x04288bbd939adb/info
-        /ocpu/tmp/x04288bbd939adb/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:55:10
+        /ocpu/tmp/x0a03132e45009a/R/.val
+        /ocpu/tmp/x0a03132e45009a/R/credentials
+        /ocpu/tmp/x0a03132e45009a/R/get_acoustic_detections_page
+        /ocpu/tmp/x0a03132e45009a/stdout
+        /ocpu/tmp/x0a03132e45009a/source
+        /ocpu/tmp/x0a03132e45009a/console
+        /ocpu/tmp/x0a03132e45009a/info
+        /ocpu/tmp/x0a03132e45009a/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:07:27
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x04288bbd939adb/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x0a03132e45009a/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:55:10 GMT
+      date: Fri, 19 Sep 2025 12:07:27 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -212,7 +212,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:11 UTC
+      x-ocpu-time: 2025-09-19 12:07:28 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -18397,7 +18397,7 @@ http_interactions:
         HzR52VR1cpXOFpsndWeLsmi7o+Hq6PyeG6
         wP78CjppiW8au2VVJWRZMn9fITbi6uFnWWJ5Ni
         tr5j/3OWTGbpdP2c1cecxz/O8muGcPMTdwhIIw==
-  recorded_at: 2025-09-10 14:55:12
+  recorded_at: 2025-09-19 12:07:28
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -18406,22 +18406,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:12 GMT
+      date: Fri, 19 Sep 2025 12:07:29 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0c7c6dd09ec23a
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0c7c6dd09ec23a/
+      x-ocpu-session: x0af54d7f5d872b
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0af54d7f5d872b/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:14 UTC
+      x-ocpu-time: 2025-09-19 12:07:31 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -18429,7 +18429,7 @@ http_interactions:
       content-length: '49'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
         [
@@ -18437,31 +18437,31 @@ http_interactions:
             "count": 101401
           }
         ]
-  recorded_at: 2025-09-10 14:55:15
+  recorded_at: 2025-09-19 12:07:31
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":["VR2W-124070","VR2W-124078"],"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":["VR2W-124070","VR2W-124078"],"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:15 GMT
+      date: Fri, 19 Sep 2025 12:07:31 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0343a47839face
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0343a47839face/
+      x-ocpu-session: x008a6236a47812
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x008a6236a47812/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:19 UTC
+      x-ocpu-time: 2025-09-19 12:07:35 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -18472,23 +18472,23 @@ http_interactions:
       set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
-        /ocpu/tmp/x0343a47839face/R/.val
-        /ocpu/tmp/x0343a47839face/R/credentials
-        /ocpu/tmp/x0343a47839face/R/get_acoustic_detections_page
-        /ocpu/tmp/x0343a47839face/R/receiver_id
-        /ocpu/tmp/x0343a47839face/stdout
-        /ocpu/tmp/x0343a47839face/source
-        /ocpu/tmp/x0343a47839face/console
-        /ocpu/tmp/x0343a47839face/info
-        /ocpu/tmp/x0343a47839face/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:55:19
+        /ocpu/tmp/x008a6236a47812/R/.val
+        /ocpu/tmp/x008a6236a47812/R/credentials
+        /ocpu/tmp/x008a6236a47812/R/get_acoustic_detections_page
+        /ocpu/tmp/x008a6236a47812/R/receiver_id
+        /ocpu/tmp/x008a6236a47812/stdout
+        /ocpu/tmp/x008a6236a47812/source
+        /ocpu/tmp/x008a6236a47812/console
+        /ocpu/tmp/x008a6236a47812/info
+        /ocpu/tmp/x008a6236a47812/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:07:35
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0343a47839face/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x008a6236a47812/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:55:19 GMT
+      date: Fri, 19 Sep 2025 12:07:35 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -18502,7 +18502,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:20 UTC
+      x-ocpu-time: 2025-09-19 12:07:36 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -42630,31 +42630,31 @@ http_interactions:
         wo+uzzy+2T/Xm8uji8uz69Ojq5SN8fcOXz65OTo+enJ2/uo3v
         /+nk6Mn58eev7ufbh/l0++K8fJqbzb
         /+DYSQbzc=
-  recorded_at: 2025-09-10 14:55:21
+  recorded_at: 2025-09-19 12:07:37
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":791315184,"page_size":100000,"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":["VR2W-124070","VR2W-124078"],"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":["VR2W-124070","VR2W-124078"],"station_name":null,"next_id_pk":791315184,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:21 GMT
+      date: Fri, 19 Sep 2025 12:07:37 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0b39a51b2bd162
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0b39a51b2bd162/
+      x-ocpu-session: x07f50bf4dd3157
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x07f50bf4dd3157/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:24 UTC
+      x-ocpu-time: 2025-09-19 12:07:40 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -42662,26 +42662,26 @@ http_interactions:
       content-length: '146'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x0b39a51b2bd162/R/.val
-        /ocpu/tmp/x0b39a51b2bd162/R/credentials
-        /ocpu/tmp/x0b39a51b2bd162/R/get_acoustic_detections_page
-        /ocpu/tmp/x0b39a51b2bd162/R/receiver_id
-        /ocpu/tmp/x0b39a51b2bd162/stdout
-        /ocpu/tmp/x0b39a51b2bd162/source
-        /ocpu/tmp/x0b39a51b2bd162/console
-        /ocpu/tmp/x0b39a51b2bd162/info
-        /ocpu/tmp/x0b39a51b2bd162/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:55:24
+        /ocpu/tmp/x07f50bf4dd3157/R/.val
+        /ocpu/tmp/x07f50bf4dd3157/R/credentials
+        /ocpu/tmp/x07f50bf4dd3157/R/get_acoustic_detections_page
+        /ocpu/tmp/x07f50bf4dd3157/R/receiver_id
+        /ocpu/tmp/x07f50bf4dd3157/stdout
+        /ocpu/tmp/x07f50bf4dd3157/source
+        /ocpu/tmp/x07f50bf4dd3157/console
+        /ocpu/tmp/x07f50bf4dd3157/info
+        /ocpu/tmp/x07f50bf4dd3157/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:07:40
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0b39a51b2bd162/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x07f50bf4dd3157/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:55:25 GMT
+      date: Fri, 19 Sep 2025 12:07:40 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -42695,7 +42695,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:25 UTC
+      x-ocpu-time: 2025-09-19 12:07:41 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -42703,7 +42703,7 @@ http_interactions:
       content-length: '9195'
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       raw_gzip: |-
         eJztnQeYnVW5tnd6JsmkBzChhGKhBJIhEALpvU0yCV2EcUgmMJhMwmQSiLRA1gKpIiAoAiIo
@@ -43032,5 +43032,5 @@ http_interactions:
         86G5Hu+HfzY4YFnTQc281NYl9c1LmpY11resf4YfbLxkecv8xvqFTYve36PLofP
         rFy5qOOj9
         xylPczG/OetfZqWy9t8AzHo8OA==
-  recorded_at: 2025-09-10 14:55:26
+  recorded_at: 2025-09-19 12:07:41
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_scientific_name.yml
+++ b/tests/fixtures/detections_scientific_name.yml
@@ -7,29 +7,29 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:52:13 GMT
+      date: Fri, 19 Sep 2025 12:04:40 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x04aedf47942d95
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x04aedf47942d95/
+      x-ocpu-session: x0c4f6942cce4ec
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0c4f6942cce4ec/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:14 UTC
+      x-ocpu-time: 2025-09-19 12:04:41 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
       content-length: '638'
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       raw_gzip: |-
         eJyVVM1u2zAMvvcphKLAHKAzlnTrj1EUWIsBOxQY0MN2KAqHVhhbqyIZkpy2t2GHPUGw054u
@@ -54,7 +54,7 @@ http_interactions:
         2ZAzLMw6XSct6Z0x2iTgnKERoftlf2HL/ZF/dZPQ7FU0Fc/TNT2fq4tpMj0njSBxMfUE6n
         wf
         5wEcFWIO6H6sEq5m/niSRol0k3WAIX4od7T3E+IhRwM=
-  recorded_at: 2025-09-10 14:52:15
+  recorded_at: 2025-09-19 12:04:41
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -64,29 +64,29 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:52:15 GMT
+      date: Fri, 19 Sep 2025 12:04:41 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x07c60d83fe2b15
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x07c60d83fe2b15/
+      x-ocpu-session: x051b6b85496ee2
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x051b6b85496ee2/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:16 UTC
+      x-ocpu-time: 2025-09-19 12:04:42 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
       content-length: '633'
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       raw_gzip: |-
         eJyVVM1u2zAMvvcphKLAHKAzlnTrj1EUWIsBOxQY0MN2KIqEVhhbqyIZkpwmt2GHPUGw054u
@@ -111,7 +111,7 @@ http_interactions:
         p6ukIb0zRpsEnDM0InS/HM5tcTjwr24Umr2OpuJ5uiaXM3U1SSaXpBEkriaeQJ3v4jyBo0
         LM
         Ed2PZcLV1B+P0iiRdrKOMMQP5Q4OfgL16kgD
-  recorded_at: 2025-09-10 14:52:16
+  recorded_at: 2025-09-19 12:04:42
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -121,29 +121,29 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:52:16 GMT
+      date: Fri, 19 Sep 2025 12:04:42 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x08ff7542a5bd06
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x08ff7542a5bd06/
+      x-ocpu-session: x047c58bcd1b87a
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x047c58bcd1b87a/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:17 UTC
+      x-ocpu-time: 2025-09-19 12:04:43 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
       content-length: '648'
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       raw_gzip: |-
         eJyVVM1q3DAQvucpRAjUC6nb3bT5MSHQhEIPgUIO7SEEe6ydtdVoJSPJm+RWcugTLD316fIk
@@ -168,7 +168,7 @@ http_interactions:
         ca4Gl2XdPPdGzzkZcoaJWaebpCO9N0abBJwz1CL0vuzObbU78kc3CcVeRl3x3F3F6UydFU
         lx
         ShpB4qzwBKp87+cOHCVi9uh9rBOupn57kkaBrDprD4P/kO5o5ycNPFB2
-  recorded_at: 2025-09-10 14:52:17
+  recorded_at: 2025-09-19 12:04:43
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -178,22 +178,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:52:17 GMT
+      date: Fri, 19 Sep 2025 12:04:43 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0ff3a48dbca82b
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0ff3a48dbca82b/
+      x-ocpu-session: x01beb088a12e69
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x01beb088a12e69/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:19 UTC
+      x-ocpu-time: 2025-09-19 12:04:44 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -201,7 +201,7 @@ http_interactions:
       content-length: '48'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
         [
@@ -209,58 +209,58 @@ http_interactions:
             "count": 20367
           }
         ]
-  recorded_at: 2025-09-10 14:52:19
+  recorded_at: 2025-09-19 12:04:44
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":"Torpedo
-        torpedo","acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":"Torpedo
+        torpedo","acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:52:19 GMT
+      date: Fri, 19 Sep 2025 12:04:44 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x048e8b0718d88e
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x048e8b0718d88e/
+      x-ocpu-session: x092f188c4b32f0
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x092f188c4b32f0/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:21 UTC
+      x-ocpu-time: 2025-09-19 12:04:45 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '137'
+      content-length: '138'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
       set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x048e8b0718d88e/R/.val
-        /ocpu/tmp/x048e8b0718d88e/R/credentials
-        /ocpu/tmp/x048e8b0718d88e/R/get_acoustic_detections_page
-        /ocpu/tmp/x048e8b0718d88e/stdout
-        /ocpu/tmp/x048e8b0718d88e/source
-        /ocpu/tmp/x048e8b0718d88e/console
-        /ocpu/tmp/x048e8b0718d88e/info
-        /ocpu/tmp/x048e8b0718d88e/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:52:21
+        /ocpu/tmp/x092f188c4b32f0/R/.val
+        /ocpu/tmp/x092f188c4b32f0/R/credentials
+        /ocpu/tmp/x092f188c4b32f0/R/get_acoustic_detections_page
+        /ocpu/tmp/x092f188c4b32f0/stdout
+        /ocpu/tmp/x092f188c4b32f0/source
+        /ocpu/tmp/x092f188c4b32f0/console
+        /ocpu/tmp/x092f188c4b32f0/info
+        /ocpu/tmp/x092f188c4b32f0/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:04:45
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x048e8b0718d88e/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x092f188c4b32f0/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:52:21 GMT
+      date: Fri, 19 Sep 2025 12:04:45 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -274,7 +274,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:22 UTC
+      x-ocpu-time: 2025-09-19 12:04:46 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -4822,7 +4822,7 @@ http_interactions:
         k1H16fsf3VH+uMN4XSrtlRP/lbbjXK9UWtV
         y821v8KNH9zoNOer5cXacv9nTJ6bLy8uV5b6v8/6X+ZK
         8m/O2t9mCJ/8C9j174o=
-  recorded_at: 2025-09-10 14:52:22
+  recorded_at: 2025-09-19 12:04:46
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -4832,22 +4832,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:52:22 GMT
+      date: Fri, 19 Sep 2025 12:04:46 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x02066cd92668b0
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x02066cd92668b0/
+      x-ocpu-session: x0ce27d7887ea80
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0ce27d7887ea80/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:23 UTC
+      x-ocpu-time: 2025-09-19 12:04:48 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -4855,7 +4855,7 @@ http_interactions:
       content-length: '48'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
         [
@@ -4863,59 +4863,59 @@ http_interactions:
             "count": 21349
           }
         ]
-  recorded_at: 2025-09-10 14:52:23
+  recorded_at: 2025-09-19 12:04:48
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":["Raja
-        asterias","Torpedo torpedo"],"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":["Raja
+        asterias","Torpedo torpedo"],"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:52:23 GMT
+      date: Fri, 19 Sep 2025 12:04:48 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0ebf8889dee7c5
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0ebf8889dee7c5/
+      x-ocpu-session: x0f596f7aed395a
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0f596f7aed395a/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:25 UTC
+      x-ocpu-time: 2025-09-19 12:04:49 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '146'
+      content-length: '147'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
       set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x0ebf8889dee7c5/R/.val
-        /ocpu/tmp/x0ebf8889dee7c5/R/credentials
-        /ocpu/tmp/x0ebf8889dee7c5/R/get_acoustic_detections_page
-        /ocpu/tmp/x0ebf8889dee7c5/R/scientific_name
-        /ocpu/tmp/x0ebf8889dee7c5/stdout
-        /ocpu/tmp/x0ebf8889dee7c5/source
-        /ocpu/tmp/x0ebf8889dee7c5/console
-        /ocpu/tmp/x0ebf8889dee7c5/info
-        /ocpu/tmp/x0ebf8889dee7c5/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:52:25
+        /ocpu/tmp/x0f596f7aed395a/R/.val
+        /ocpu/tmp/x0f596f7aed395a/R/credentials
+        /ocpu/tmp/x0f596f7aed395a/R/get_acoustic_detections_page
+        /ocpu/tmp/x0f596f7aed395a/R/scientific_name
+        /ocpu/tmp/x0f596f7aed395a/stdout
+        /ocpu/tmp/x0f596f7aed395a/source
+        /ocpu/tmp/x0f596f7aed395a/console
+        /ocpu/tmp/x0f596f7aed395a/info
+        /ocpu/tmp/x0f596f7aed395a/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:04:49
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0ebf8889dee7c5/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x0f596f7aed395a/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:52:25 GMT
+      date: Fri, 19 Sep 2025 12:04:49 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -4929,14 +4929,14 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:52:26 UTC
+      x-ocpu-time: 2025-09-19 12:04:50 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       raw_gzip: |-
         eJwU13+8bHs9P/BL9UUoKT8iOqGIbu6miCShH7fumkm/f5+ZtfasPbPmnD37zN5D+nFrbyS3
@@ -9809,5 +9809,5 @@ http_interactions:
         y1eaX9sdDar5pXOzS9k/3Obi4gq8OB1sj+JbrcbFaDyYlsXk4A6XB49
         3J72y2BoMF2c881mv
         2Bp2txevM7vNnfjNOXibIfz1N5t89wo=
-  recorded_at: 2025-09-10 14:52:26
+  recorded_at: 2025-09-19 12:04:50
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_station_name.yml
+++ b/tests/fixtures/detections_station_name.yml
@@ -7,29 +7,29 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:55:26 GMT
+      date: Fri, 19 Sep 2025 12:07:42 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0f2135bbd43ee4
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0f2135bbd43ee4/
+      x-ocpu-session: x009cfbea9e0cb7
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x009cfbea9e0cb7/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:27 UTC
+      x-ocpu-time: 2025-09-19 12:07:43 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
       content-length: '650'
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       raw_gzip: |-
         eJyVVFFP2zAQfudXnBDSUimEpgUKEWKCjsEDExND4wGh1CRHYzW1I9ul42Wa9rBfUO1pv45f
@@ -54,7 +54,7 @@ http_interactions:
         OMZkzETRfB1bo+bsNznNxLSRhTcnnSgllceMUdQi2of1sR6ut+zRdcpiz5yueO6uwcG9OB
         x4
         gwPSKCUOB5ZAla/9TJmhRNRGMdGZl4jUvu4ETiBVZ21g6b9Mt7X2G4qaJrs=
-  recorded_at: 2025-09-10 14:55:27
+  recorded_at: 2025-09-19 12:07:43
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -63,22 +63,22 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:55:27 GMT
+      date: Fri, 19 Sep 2025 12:07:43 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0bd3ab702825a6
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0bd3ab702825a6/
+      x-ocpu-session: x07ba6a00afa9a1
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x07ba6a00afa9a1/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:29 UTC
+      x-ocpu-time: 2025-09-19 12:07:44 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -110,7 +110,7 @@ http_interactions:
         sa3DM2XPpdQkpoljTM5MFM3XsTVqzn6T00xMGzn25qQTpaTymDGKWkT7sD7Sg/WWPbpOWe
         yZ
         0xXP3ZUc3IvDxEsOSKOUOEwsgSpf+5kyQ4mojfFE514qMvu6EziBVJ21gaX/Mt3W2m/p7Cst
-  recorded_at: 2025-09-10 14:55:29
+  recorded_at: 2025-09-19 12:07:44
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -119,22 +119,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:29 GMT
+      date: Fri, 19 Sep 2025 12:07:44 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x076dff9352a835
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x076dff9352a835/
+      x-ocpu-session: x0ed52ac2472f2f
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0ed52ac2472f2f/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:30 UTC
+      x-ocpu-time: 2025-09-19 12:07:45 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -150,57 +150,57 @@ http_interactions:
             "count": 14927
           }
         ]
-  recorded_at: 2025-09-10 14:55:30
+  recorded_at: 2025-09-19 12:07:46
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":"de-9"}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":"de-9","next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:30 GMT
+      date: Fri, 19 Sep 2025 12:07:46 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0775091fd54680
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0775091fd54680/
+      x-ocpu-session: x067c0065ce6b1c
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x067c0065ce6b1c/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:32 UTC
+      x-ocpu-time: 2025-09-19 12:07:47 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '139'
+      content-length: '137'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
       set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
-        /ocpu/tmp/x0775091fd54680/R/.val
-        /ocpu/tmp/x0775091fd54680/R/credentials
-        /ocpu/tmp/x0775091fd54680/R/get_acoustic_detections_page
-        /ocpu/tmp/x0775091fd54680/stdout
-        /ocpu/tmp/x0775091fd54680/source
-        /ocpu/tmp/x0775091fd54680/console
-        /ocpu/tmp/x0775091fd54680/info
-        /ocpu/tmp/x0775091fd54680/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:55:32
+        /ocpu/tmp/x067c0065ce6b1c/R/.val
+        /ocpu/tmp/x067c0065ce6b1c/R/credentials
+        /ocpu/tmp/x067c0065ce6b1c/R/get_acoustic_detections_page
+        /ocpu/tmp/x067c0065ce6b1c/stdout
+        /ocpu/tmp/x067c0065ce6b1c/source
+        /ocpu/tmp/x067c0065ce6b1c/console
+        /ocpu/tmp/x067c0065ce6b1c/info
+        /ocpu/tmp/x067c0065ce6b1c/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:07:47
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0775091fd54680/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x067c0065ce6b1c/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:55:32 GMT
+      date: Fri, 19 Sep 2025 12:07:47 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -214,14 +214,14 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:32 UTC
+      x-ocpu-time: 2025-09-19 12:07:48 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       raw_gzip: |-
         eJwUl2VYlH8ThT3G3+7u7m7d7l27u7u7C7uwEwVsxULswO4ODGwURTFRsQP0vd8Pty77/GLm
@@ -5492,7 +5492,7 @@ http_interactions:
         2a9fceeM/XFxNau/xFl6p5uvP32w4rqa3vXdtqjauonX2Wy+vlNv86rsetpb0sm963ZXeOf
         C
         w7acVumndnWs6rItYrP4huuD63mTF3FSzlZnPP2Ux8ksm67us/yal+mfs/iZIfz4CaS5MCM=
-  recorded_at: 2025-09-10 14:55:33
+  recorded_at: 2025-09-19 12:07:48
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -5501,22 +5501,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:33 GMT
+      date: Fri, 19 Sep 2025 12:07:48 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0f09102498ffb6
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0f09102498ffb6/
+      x-ocpu-session: x0976acee92e4fa
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0976acee92e4fa/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:34 UTC
+      x-ocpu-time: 2025-09-19 12:07:49 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -5524,7 +5524,7 @@ http_interactions:
       content-length: '48'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
         [
@@ -5532,58 +5532,58 @@ http_interactions:
             "count": 17147
           }
         ]
-  recorded_at: 2025-09-10 14:55:34
+  recorded_at: 2025-09-19 12:07:49
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":["de-10","de-9"]}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":["de-10","de-9"],"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:34 GMT
+      date: Fri, 19 Sep 2025 12:07:49 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x00ba296935b027
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x00ba296935b027/
+      x-ocpu-session: x06f27ecf16fad9
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x06f27ecf16fad9/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:36 UTC
+      x-ocpu-time: 2025-09-19 12:07:51 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '146'
+      content-length: '144'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
       set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
-        /ocpu/tmp/x00ba296935b027/R/.val
-        /ocpu/tmp/x00ba296935b027/R/credentials
-        /ocpu/tmp/x00ba296935b027/R/get_acoustic_detections_page
-        /ocpu/tmp/x00ba296935b027/R/station_name
-        /ocpu/tmp/x00ba296935b027/stdout
-        /ocpu/tmp/x00ba296935b027/source
-        /ocpu/tmp/x00ba296935b027/console
-        /ocpu/tmp/x00ba296935b027/info
-        /ocpu/tmp/x00ba296935b027/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:55:36
+        /ocpu/tmp/x06f27ecf16fad9/R/.val
+        /ocpu/tmp/x06f27ecf16fad9/R/credentials
+        /ocpu/tmp/x06f27ecf16fad9/R/get_acoustic_detections_page
+        /ocpu/tmp/x06f27ecf16fad9/R/station_name
+        /ocpu/tmp/x06f27ecf16fad9/stdout
+        /ocpu/tmp/x06f27ecf16fad9/source
+        /ocpu/tmp/x06f27ecf16fad9/console
+        /ocpu/tmp/x06f27ecf16fad9/info
+        /ocpu/tmp/x06f27ecf16fad9/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:07:51
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x00ba296935b027/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x06f27ecf16fad9/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:55:36 GMT
+      date: Fri, 19 Sep 2025 12:07:51 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -5597,7 +5597,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:37 UTC
+      x-ocpu-time: 2025-09-19 12:07:52 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -12131,5 +12131,5 @@ http_interactions:
         3v0bvPWLX16evDjbrurV+frs/ORys7
         54u4TvP/j81cXxZv385PTmM3719+P189OjFzff824x
         X243ztvVXK3+/R+wctzH
-  recorded_at: 2025-09-10 14:55:37
+  recorded_at: 2025-09-19 12:07:52
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_tag_date_range.yml
+++ b/tests/fixtures/detections_tag_date_range.yml
@@ -7,22 +7,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:57 GMT
+      date: Fri, 19 Sep 2025 12:08:10 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x028da724f03316
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x028da724f03316/
+      x-ocpu-session: x06eef3a6fa7d3d
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x06eef3a6fa7d3d/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:55:59 UTC
+      x-ocpu-time: 2025-09-19 12:08:12 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -38,57 +38,57 @@ http_interactions:
             "count": 47213
           }
         ]
-  recorded_at: 2025-09-10 14:55:59
+  recorded_at: 2025-09-19 12:08:12
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":"2010-08-09","end_date":"2011-05-19","acoustic_tag_id":"A69-1303-20695","animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2010-08-09","end_date":"2011-05-19","acoustic_tag_id":"A69-1303-20695","animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:55:59 GMT
+      date: Fri, 19 Sep 2025 12:08:12 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0fb1eefbc5980e
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0fb1eefbc5980e/
+      x-ocpu-session: x0d61e5bd3506d8
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0d61e5bd3506d8/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:56:02 UTC
+      x-ocpu-time: 2025-09-19 12:08:15 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '136'
+      content-length: '137'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
       set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x0fb1eefbc5980e/R/.val
-        /ocpu/tmp/x0fb1eefbc5980e/R/credentials
-        /ocpu/tmp/x0fb1eefbc5980e/R/get_acoustic_detections_page
-        /ocpu/tmp/x0fb1eefbc5980e/stdout
-        /ocpu/tmp/x0fb1eefbc5980e/source
-        /ocpu/tmp/x0fb1eefbc5980e/console
-        /ocpu/tmp/x0fb1eefbc5980e/info
-        /ocpu/tmp/x0fb1eefbc5980e/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:56:02
+        /ocpu/tmp/x0d61e5bd3506d8/R/.val
+        /ocpu/tmp/x0d61e5bd3506d8/R/credentials
+        /ocpu/tmp/x0d61e5bd3506d8/R/get_acoustic_detections_page
+        /ocpu/tmp/x0d61e5bd3506d8/stdout
+        /ocpu/tmp/x0d61e5bd3506d8/source
+        /ocpu/tmp/x0d61e5bd3506d8/console
+        /ocpu/tmp/x0d61e5bd3506d8/info
+        /ocpu/tmp/x0d61e5bd3506d8/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:08:15
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0fb1eefbc5980e/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x0d61e5bd3506d8/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:56:02 GMT
+      date: Fri, 19 Sep 2025 12:08:15 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -102,14 +102,14 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:56:03 UTC
+      x-ocpu-time: 2025-09-19 12:08:16 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       raw_gzip: |-
         eJwU13lc3fl71/1Jd6u1amtrF2207U/t4nK3VTuQZLKQ/AKH/XBYQoCwJAMHDvsStkMIhABh
@@ -11104,7 +11104,7 @@ http_interactions:
         f/HZzfnh4WDv6PGNcTEYD0f5Qbu3v3ik2bH9QVnNDm0eHsr+4TbmB4/A++Nybx
         BfajXMB8Ny
         XOSj+hkuTjzcH3WKfLfszc9x9/1Ovttr780f5/Bp9uMXp36ZIfz5FwbhwgE=
-  recorded_at: 2025-09-10 14:56:03
+  recorded_at: 2025-09-19 12:08:16
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -11113,62 +11113,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:56:03 GMT
+      date: Fri, 19 Sep 2025 12:08:16 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x07770262e7e1d9
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x07770262e7e1d9/
+      x-ocpu-session: x001e4cc5bb2e05
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x001e4cc5bb2e05/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:56:05 UTC
-      x-ocpu-version: 2.2.14
-      x-ocpu-server: rApache
-      vary: Accept-Encoding
-      content-encoding: gzip
-      content-length: '44'
-      content-type: application/json
-      access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
-    body:
-      string: |
-        [
-          {
-            "count": 0
-          }
-        ]
-  recorded_at: 2025-09-10 14:56:06
-- request:
-    method: POST
-    uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
-    body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2011-05-19","end_date":null,"acoustic_tag_id":"A69-1303-20695","animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"count":true}'
-  response:
-    status: 201
-    headers:
-      date: Wed, 10 Sep 2025 14:56:06 GMT
-      server: Apache/2.4.58 (Ubuntu)
-      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
-        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
-        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
-      cross-origin-opener-policy: same-origin
-      cache-control: max-age=300, public
-      x-ocpu-session: x0a900b30a77367
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0a900b30a77367/
-      access-control-allow-origin: '*'
-      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
-      access-control-allow-headers: '*'
-      access-control-allow-credentials: 'true'
-      x-ocpu-r: R version 4.5.0 (2025-04-11)
-      x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:56:08 UTC
+      x-ocpu-time: 2025-09-19 12:08:18 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -11184,5 +11144,45 @@ http_interactions:
             "count": 0
           }
         ]
-  recorded_at: 2025-09-10 14:56:08
+  recorded_at: 2025-09-19 12:08:18
+- request:
+    method: POST
+    uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
+    body:
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2011-05-19","end_date":null,"acoustic_tag_id":"A69-1303-20695","animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"count":true}'
+  response:
+    status: 201
+    headers:
+      date: Fri, 19 Sep 2025 12:08:18 GMT
+      server: Apache/2.4.58 (Ubuntu)
+      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
+        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
+        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
+      cross-origin-opener-policy: same-origin
+      cache-control: max-age=300, public
+      x-ocpu-session: x04b7c3a6642fa8
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x04b7c3a6642fa8/
+      access-control-allow-origin: '*'
+      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
+      access-control-allow-headers: '*'
+      access-control-allow-credentials: 'true'
+      x-ocpu-r: R version 4.5.0 (2025-04-11)
+      x-ocpu-locale: C.UTF-8
+      x-ocpu-time: 2025-09-19 12:08:20 UTC
+      x-ocpu-version: 2.2.14
+      x-ocpu-server: rApache
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-length: '44'
+      content-type: application/json
+      access-control-allow-methods: '*'
+      set-cookie: vliz_webc=vliz_webc2; path=/
+    body:
+      string: |
+        [
+          {
+            "count": 0
+          }
+        ]
+  recorded_at: 2025-09-19 12:08:20
 recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_tag_id.yml
+++ b/tests/fixtures/detections_tag_id.yml
@@ -7,29 +7,29 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:51:32 GMT
+      date: Fri, 19 Sep 2025 12:04:09 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0cb74354a4a897
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0cb74354a4a897/
+      x-ocpu-session: x00131c9aa8a2bc
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x00131c9aa8a2bc/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:34 UTC
+      x-ocpu-time: 2025-09-19 12:04:10 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
       content-length: '582'
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       raw_gzip: |-
         eJyVVN1q2zAUvs9TiFKYDamJZNmOTenFyqAXhcEutotQbNVWExFPDpKSjl2NXewJwq72dHmS
@@ -52,7 +52,7 @@ http_interactions:
         uDGpmo3Xid4J0QiPKCX0isgpuPgslxe+uTrUDnvvbMVxu4rrJ35TeMW19mgtbgo
         j0JMfcp6J
         0o2Iy81WrrySV+YxCpxC+s26pG1+264/+Q1+JyBK
-  recorded_at: 2025-09-10 14:51:34
+  recorded_at: 2025-09-19 12:04:10
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -61,22 +61,22 @@ http_interactions:
   response:
     status: 400
     headers:
-      date: Wed, 10 Sep 2025 14:51:34 GMT
+      date: Fri, 19 Sep 2025 12:04:10 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0c3ac936bd7b0d
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0c3ac936bd7b0d/
+      x-ocpu-session: x08ddf2be43811e
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x08ddf2be43811e/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:36 UTC
+      x-ocpu-time: 2025-09-19 12:04:12 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -106,7 +106,7 @@ http_interactions:
         tmQQYaE0Uq6wzLIuzjUYNOlYM25MyGbjdKJ3nDfcwVJytSJiCi4+ieWFq48OtcP
         eW1tx3K7i
         6oldF05xpTxai+tCC9TkhzzPWKpG+OVmK1ZOySr9GnlWIf1mXZI2f9uuO/kFDEwmWg==
-  recorded_at: 2025-09-10 14:51:36
+  recorded_at: 2025-09-19 12:04:12
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -115,22 +115,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:36 GMT
+      date: Fri, 19 Sep 2025 12:04:12 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0fabea4d8af83e
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0fabea4d8af83e/
+      x-ocpu-session: x0ddcd29dad119d
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0ddcd29dad119d/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:38 UTC
+      x-ocpu-time: 2025-09-19 12:04:13 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -138,7 +138,7 @@ http_interactions:
       content-length: '48'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
         [
@@ -146,57 +146,57 @@ http_interactions:
             "count": 10994
           }
         ]
-  recorded_at: 2025-09-10 14:51:38
+  recorded_at: 2025-09-19 12:04:13
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":null,"acoustic_tag_id":"A69-1601-16130","animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":"A69-1601-16130","animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:38 GMT
+      date: Fri, 19 Sep 2025 12:04:13 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0c40946e7fce51
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0c40946e7fce51/
+      x-ocpu-session: x05f21e7ab1be60
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x05f21e7ab1be60/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:41 UTC
+      x-ocpu-time: 2025-09-19 12:04:15 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '137'
+      content-length: '138'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
-        /ocpu/tmp/x0c40946e7fce51/R/.val
-        /ocpu/tmp/x0c40946e7fce51/R/credentials
-        /ocpu/tmp/x0c40946e7fce51/R/get_acoustic_detections_page
-        /ocpu/tmp/x0c40946e7fce51/stdout
-        /ocpu/tmp/x0c40946e7fce51/source
-        /ocpu/tmp/x0c40946e7fce51/console
-        /ocpu/tmp/x0c40946e7fce51/info
-        /ocpu/tmp/x0c40946e7fce51/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:51:41
+        /ocpu/tmp/x05f21e7ab1be60/R/.val
+        /ocpu/tmp/x05f21e7ab1be60/R/credentials
+        /ocpu/tmp/x05f21e7ab1be60/R/get_acoustic_detections_page
+        /ocpu/tmp/x05f21e7ab1be60/stdout
+        /ocpu/tmp/x05f21e7ab1be60/source
+        /ocpu/tmp/x05f21e7ab1be60/console
+        /ocpu/tmp/x05f21e7ab1be60/info
+        /ocpu/tmp/x05f21e7ab1be60/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:04:15
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x0c40946e7fce51/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x05f21e7ab1be60/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:51:41 GMT
+      date: Fri, 19 Sep 2025 12:04:15 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -210,14 +210,14 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:42 UTC
+      x-ocpu-time: 2025-09-19 12:04:16 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
       content-type: application/r-rds
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       raw_gzip: |-
         eJwUl2N4nV0Thbtq23bf2jq2ayO1bdu2badKbRuplZppUyN1v/v7cfec8zx7z55Zs2Zfaf2k
@@ -3367,7 +3367,7 @@ http_interactions:
         dLLcnXpxf+rXg+tO65ONC18vJhfT9VSXs8F0NlmMB/PNCPeEZ9fz0XhwPrmsaXzz+2hw
         fjm8
         qPu5H+bVmjmbaVbVv/8B1qicaw==
-  recorded_at: 2025-09-10 14:51:42
+  recorded_at: 2025-09-19 12:04:16
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
@@ -3376,22 +3376,22 @@ http_interactions:
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:42 GMT
+      date: Fri, 19 Sep 2025 12:04:16 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x0fd6673a885acf
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x0fd6673a885acf/
+      x-ocpu-session: x0ee7d1ab5e7c02
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0ee7d1ab5e7c02/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:44 UTC
+      x-ocpu-time: 2025-09-19 12:04:18 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -3399,7 +3399,7 @@ http_interactions:
       content-length: '48'
       content-type: application/json
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc1; path=/
+      set-cookie: vliz_webc=vliz_webc2; path=/
     body:
       string: |
         [
@@ -3407,58 +3407,58 @@ http_interactions:
             "count": 11030
           }
         ]
-  recorded_at: 2025-09-10 14:51:44
+  recorded_at: 2025-09-19 12:04:18
 - request:
     method: POST
     uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
     body:
-      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"next_id_pk":0,"page_size":100000,"start_date":null,"end_date":null,"acoustic_tag_id":["A69-1601-16129","A69-1601-16130"],"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null}'
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":null,"end_date":null,"acoustic_tag_id":["A69-1601-16129","A69-1601-16130"],"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":null,"next_id_pk":0,"page_size":100000,"credentials.1":null}'
   response:
     status: 201
     headers:
-      date: Wed, 10 Sep 2025 14:51:44 GMT
+      date: Fri, 19 Sep 2025 12:04:18 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
         form.vliz.be www.omes-monitoring.be omes-monitoring.be;
       cross-origin-opener-policy: same-origin
       cache-control: max-age=300, public
-      x-ocpu-session: x03ce3df8337fb1
-      location: http://opencpu.lifewatch.be/ocpu/tmp/x03ce3df8337fb1/
+      x-ocpu-session: x0e1705a32383de
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0e1705a32383de/
       access-control-allow-origin: '*'
       access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
       access-control-allow-headers: '*'
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:47 UTC
+      x-ocpu-time: 2025-09-19 12:04:20 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
       content-encoding: gzip
-      content-length: '143'
+      content-length: '144'
       content-type: text/plain; charset=utf-8
       access-control-allow-methods: '*'
-      set-cookie: vliz_webc=vliz_webc2; path=/
+      set-cookie: vliz_webc=vliz_webc1; path=/
     body:
       string: |
-        /ocpu/tmp/x03ce3df8337fb1/R/.val
-        /ocpu/tmp/x03ce3df8337fb1/R/acoustic_tag_id
-        /ocpu/tmp/x03ce3df8337fb1/R/credentials
-        /ocpu/tmp/x03ce3df8337fb1/R/get_acoustic_detections_page
-        /ocpu/tmp/x03ce3df8337fb1/stdout
-        /ocpu/tmp/x03ce3df8337fb1/source
-        /ocpu/tmp/x03ce3df8337fb1/console
-        /ocpu/tmp/x03ce3df8337fb1/info
-        /ocpu/tmp/x03ce3df8337fb1/files/DESCRIPTION
-  recorded_at: 2025-09-10 14:51:47
+        /ocpu/tmp/x0e1705a32383de/R/.val
+        /ocpu/tmp/x0e1705a32383de/R/acoustic_tag_id
+        /ocpu/tmp/x0e1705a32383de/R/credentials
+        /ocpu/tmp/x0e1705a32383de/R/get_acoustic_detections_page
+        /ocpu/tmp/x0e1705a32383de/stdout
+        /ocpu/tmp/x0e1705a32383de/source
+        /ocpu/tmp/x0e1705a32383de/console
+        /ocpu/tmp/x0e1705a32383de/info
+        /ocpu/tmp/x0e1705a32383de/files/DESCRIPTION
+  recorded_at: 2025-09-19 12:04:20
 - request:
     method: GET
-    uri: https://opencpu.lifewatch.be/tmp/x03ce3df8337fb1/R/.val/rds
+    uri: https://opencpu.lifewatch.be/tmp/x0e1705a32383de/R/.val/rds
   response:
     status: 200
     headers:
-      date: Wed, 10 Sep 2025 14:51:47 GMT
+      date: Fri, 19 Sep 2025 12:04:20 GMT
       server: Apache/2.4.58 (Ubuntu)
       content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
         'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
@@ -3472,7 +3472,7 @@ http_interactions:
       access-control-allow-credentials: 'true'
       x-ocpu-r: R version 4.5.0 (2025-04-11)
       x-ocpu-locale: C.UTF-8
-      x-ocpu-time: 2025-09-10 14:51:48 UTC
+      x-ocpu-time: 2025-09-19 12:04:21 UTC
       x-ocpu-version: 2.2.14
       x-ocpu-server: rApache
       vary: Accept-Encoding
@@ -6673,5 +6673,5 @@ http_interactions:
         R+4e78WWw29Xs5fzbVbXi9F8MVtNR8u7FB4CXtwuJ9PRi9nNPoxf/X0yenEzfrmP53MyX
         20L
         5y6bTfPf/wEpdBuN
-  recorded_at: 2025-09-10 14:51:48
+  recorded_at: 2025-09-19 12:04:21
 recorded_with: VCR-vcr/2.0.0

--- a/tests/testthat/_snaps/sql/download_acoustic_dataset.md
+++ b/tests/testthat/_snaps/sql/download_acoustic_dataset.md
@@ -25,11 +25,11 @@
       
       * number of tags:              16
       
-      * number of detections:        235810
+      * number of detections:        235809
       
-      * number of deployments:       1152
+      * number of deployments:       1036
       
-      * number of receivers:         249
+      * number of receivers:         140
       
       * first date of detection:     2014-04-18
       
@@ -37,7 +37,7 @@
       
       * included scientific names:   Petromyzon marinus, Rutilus rutilus, Silurus glanis, Squalius cephalus
       
-      * included acoustic projects:  albert, demer, dijle, V2LCHASES, zeeschelde
+      * included acoustic projects:  albert, demer, dijle, zeeschelde
       
       
       

--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -30,10 +30,12 @@ using_test_deployment <- function() {
 invisible(vcr::vcr_configure(
   filter_sensitive_data = list("<<<my_userid>>>" = Sys.getenv('ETN_USER'),
                                "<<<my_pwd>>>" = Sys.getenv('ETN_PWD')),
-  dir = vcr::vcr_test_path("fixtures"),
-  # if we are using a test deployment of OpenCPU, turn off vcr. All requests on
-  # the test deployment are performed on the live (test) API.
-  turned_off = using_test_deployment()
+  dir = vcr::vcr_test_path("fixtures")
 ))
 
+# if we are using a test deployment of OpenCPU, turn off vcr. All requests on
+# the test deployment are performed on the live (test) API.
+if(using_test_deployment()){
+  vcr::turn_off(ignore_cassettes = TRUE)
+}
 

--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -1,6 +1,39 @@
 library("vcr") # *Required* as vcr is set up on loading
+
+# Helpers for VCR ---------------------------------------------------------
+
+#' Check if tests are running on the OpenCPU test deployment
+#'
+#' If the tests are running on the OpenCPU test deployment, the production
+#' cassettes will not work. And all tests need to run on the live test API.
+#'
+#' @return Logical, `TRUE` if the tests are running on the test deployment,
+#' `FALSE` if the tests are running on the production deployment.
+#' @family helper functions
+#' @noRd
+#' @examples
+#' withr::local_envvar(ETN_TEST_API =
+#'     "https://some.secret.url/opencpu/etnservice/R")
+#' using_test_deployment()
+#' withr::local_envvar(ETN_TEST_API = NA) # unset
+#' using_test_deployment()
+using_test_deployment <- function() {
+  # Check if the ETN_TEST_API environment variable is set to anything, if not,
+  # then we are using the production deployment
+  Sys.getenv("ETN_TEST_API", unset = "URL_UNSET") != "URL_UNSET"
+}
+
+# Configure VCR -----------------------------------------------------------
+
+# Set up vcr to filter out sensitive data and store cassettes in the correct
+# folder. If we are using the test deployment of OpenCPU, turn off vcr.
 invisible(vcr::vcr_configure(
   filter_sensitive_data = list("<<<my_userid>>>" = Sys.getenv('ETN_USER'),
                                "<<<my_pwd>>>" = Sys.getenv('ETN_PWD')),
-  dir = vcr::vcr_test_path("fixtures")
+  dir = vcr::vcr_test_path("fixtures"),
+  # if we are using a test deployment of OpenCPU, turn off vcr. All requests on
+  # the test deployment are performed on the live (test) API.
+  turned_off = using_test_deployment()
 ))
+
+

--- a/tests/testthat/test-get_acoustic_detections.R
+++ b/tests/testthat/test-get_acoustic_detections.R
@@ -586,3 +586,20 @@ test_that("get_acoustic_detections() can return detections not (yet) associated 
   # not yet associated with an animal. It should return detections
   expect_gt(nrow(get_acoustic_detections(acoustic_tag_id = "A180-1702-49684")), 0)
 })
+
+test_that("get_acoustic_detections() can handle 5M+ detections: API", {
+  skip_on_ci() # This takes ages
+  df <- get_acoustic_detections(animal_project_code = "2013_albertkanaal",
+                                limit = FALSE,
+                                api = TRUE)
+  expect_s3_class(df, "data.frame")
+})
+
+test_that("get_acoustic_detections() can handle 5M+ detections: SQL", {
+  skip_on_ci() # This takes ages
+  skip_if_not_localdb()
+  df <- get_acoustic_detections(animal_project_code = "2013_albertkanaal",
+                                limit = FALSE,
+                                api = FALSE)
+  expect_s3_class(df, "data.frame")
+})


### PR DESCRIPTION
### helper logic
In this PR I refactor the logic in `get_acoustic_detections()` that decides what helper to use (local query vs api query), and more importantly, what and how to send information to the helpers. 

There was a mistake in my error in that both helpers got the user provided and calculated arguments in the same format, but this doesn't work because one expects arguments in a single object, and the other does not. 

I've tried writing it in such a manner that it's easy to maintain or change in the future, but I suppose time will tell. I've also updated cassettes to reflect the function calls in tests as the arguments are passed a bit differently to the API. 

### ifelse() oopsie
Turns out my use of  `ifelse()` causes a bug when `DBI` returns an `integer64` value, this bug caused a very large number to be passed to the cli progress bar, and thus broke the whole call; #393 

### progress bar

Finally this PR also makes a small change in how the progress bar is initialised and iterated, now keeping track of pages instead of detections to avoid overflowing the count cli can deal with. 

## AI Summary

This pull request refactors the pagination and credential handling logic in the `get_acoustic_detections` function, making it more efficient and robust. Credentials are now fetched once and reused across all paginated requests, and the arguments for pagination are assembled in a more systematic way. Additionally, the test fixtures have been updated to reflect changes in the request payload structure and to synchronize with new session and timestamp values.

**Core logic improvements:**

* Credentials are now fetched only once at the start of the `get_acoustic_detections` function and reused for every page, improving efficiency and reducing redundant calls to `get_credentials`.
* Pagination arguments (`next_id_pk`, `page_size`, and `credentials`) are now collected together with default values and combined with other arguments, streamlining the payload construction for each page fetch.
* The helper function selection and argument passing for API and SQL helper modes are refactored for clarity and maintainability.

**Test fixture updates:**

* The request payload structure in the test fixtures (`tests/fixtures/detections_acoustic_and_acoustic_archival_tags.yml`, `tests/fixtures/detections_acoustic_project_code.yml`) is updated to match the new argument assembly, including the addition of `credentials.1` and reordering of keys. [[1]](diffhunk://#diff-8edd52b72cb005e734652b7b415740caa26e84b3808ba065a478fbbc3387bb2cL10-R91) [[2]](diffhunk://#diff-8edd52b72cb005e734652b7b415740caa26e84b3808ba065a478fbbc3387bb2cL3302-R3353) [[3]](diffhunk://#diff-d41a0c2bc352b385950bbea995f2f9504e2c0317f04363afc8c9b0ce577ef1efL10-R32) [[4]](diffhunk://#diff-d41a0c2bc352b385950bbea995f2f9504e2c0317f04363afc8c9b0ce577ef1efL124-R139)
* All session IDs, timestamps, and cookie values in the fixtures are refreshed to reflect new test runs and the updated logic. [[1]](diffhunk://#diff-8edd52b72cb005e734652b7b415740caa26e84b3808ba065a478fbbc3387bb2cL10-R91) [[2]](diffhunk://#diff-8edd52b72cb005e734652b7b415740caa26e84b3808ba065a478fbbc3387bb2cL3262-R3262) [[3]](diffhunk://#diff-8edd52b72cb005e734652b7b415740caa26e84b3808ba065a478fbbc3387bb2cL3271-R3286) [[4]](diffhunk://#diff-8edd52b72cb005e734652b7b415740caa26e84b3808ba065a478fbbc3387bb2cL3367-R3375) [[5]](diffhunk://#diff-8edd52b72cb005e734652b7b415740caa26e84b3808ba065a478fbbc3387bb2cL3805-R3805) [[6]](diffhunk://#diff-d41a0c2bc352b385950bbea995f2f9504e2c0317f04363afc8c9b0ce577ef1efL57-R57) [[7]](diffhunk://#diff-d41a0c2bc352b385950bbea995f2f9504e2c0317f04363afc8c9b0ce577ef1efL66-R88) [[8]](diffhunk://#diff-d41a0c2bc352b385950bbea995f2f9504e2c0317f04363afc8c9b0ce577ef1efL115-R115) [[9]](diffhunk://#diff-d41a0c2bc352b385950bbea995f2f9504e2c0317f04363afc8c9b0ce577ef1efL124-R139)