### PR TITLE
Fixes bugs in `get_acoustic_detections()` progress reporting

### DIFF
--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -267,5 +267,8 @@ count_acoustic_detections <- function(..., api = TRUE) {
     )
   }
 
-  dplyr::pull(returned_count, "count")
+  dplyr::pull(returned_count, "count") |>
+    # If the count class is not numeric, convert it. DBI returns Integer64 which
+    # causes issues with cli progress bars
+    as.numeric()
 }

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -111,11 +111,6 @@ get_acoustic_detections <- function(connection,
       )
     ]
 
-  # Initialize progress bar for record counting
-  pb_count <- cli::cli_progress_bar("Preparing",
-                                    "tasks",
-                                    total = 1)
-
   # Calculate the number of records we expect: for progress bar + page_size
   n_records_expected <-
     if (limit) {
@@ -166,9 +161,6 @@ get_acoustic_detections <- function(connection,
     n_records_expected > 5e6 ~ 1e6,
     .default = 100000
   )
-
-  # Finish up progress bar for count step
-  cli::cli_process_done(id = pb_count)
 
   # Initialize progress bar for fetching the pages
   pb_fetch_pages <- cli::cli_progress_bar()

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -112,7 +112,7 @@ get_acoustic_detections <- function(connection,
     ]
 
   # Initialize progress bar
-  cli::cli_progress_bar(auto_terminate = FALSE)
+  pb_fetch_pages <- cli::cli_progress_bar(status = "Preparing")
 
   # Calculate the number of records we expect: for progress bar + page_size
   n_records_expected <-
@@ -169,7 +169,10 @@ get_acoustic_detections <- function(connection,
   # count query, this update doesn't count as a progress step. Otherwise we'd
   # have to add 1 more to the total number of steps.
   n_pages_expected <- ceiling(n_records_expected / page_size)
-  cli::cli_progress_update(total = n_pages_expected + 1, inc = 0)
+  cli::cli_progress_update(total = n_pages_expected + 1,
+                           inc = 0,
+                           id = pb_fetch_pages,
+                           status = "Fetching")
 
   # Init object to store pages
   combined_results <- list()
@@ -209,8 +212,7 @@ get_acoustic_detections <- function(connection,
     # Fetch page
     fetched_page <- do.call(helper_to_use, arguments_for_helper)
 
-    # Iterate the progress bar by one page
-    cli::cli_progress_update(inc = 1)
+
 
     # The next page will be fetched with detection_ids higher than the current
     # max detection_id
@@ -219,8 +221,8 @@ get_acoustic_detections <- function(connection,
     # store page: use next_id_pk as name to avoid iterating page number
     combined_results[[as.character(next_id_pk)]] <- fetched_page
 
-    # Iterate the progress bar: we fetched one page
-    cli::cli_progress_update(inc = 1)
+    # Iterate the progress bar by one page
+    cli::cli_progress_update(id = pb_fetch_pages, inc = 1)
 
     if (nrow(fetched_page) < page_size || limit) {
       # Page isn't full = end of results.

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -233,7 +233,7 @@ get_acoustic_detections <- function(connection,
   }
 
   # Update the user on final time consuming step.
-  cli::cli_progress_message("Wrapping up")
+  cli::cli_progress_message("Wrapping up...")
 
   # Combine pages and sort on acoustic_tag_id
   detections <-

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -112,6 +112,8 @@ get_acoustic_detections <- function(connection,
     ]
 
   # Calculate the number of records we expect: for progress bar + page_size
+  # Report on this step as it can take a while for large queries
+  cli::cli_progress_message("Preparing...")
   n_records_expected <-
     if (limit) {
       # If limit is set to TRUE, we expect 100 records
@@ -170,9 +172,9 @@ get_acoustic_detections <- function(connection,
   # have to add 1 more to the total number of steps.
   n_pages_expected <- ceiling(n_records_expected / page_size)
   cli::cli_progress_update(total = n_pages_expected + 1,
-                           inc = 0,
+                           set = 0,
                            id = pb_fetch_pages,
-                           status = "Fetching")
+                           status = "Getting detections.")
 
   # Init object to store pages
   combined_results <- list()
@@ -230,9 +232,10 @@ get_acoustic_detections <- function(connection,
     }
   }
 
+  # Update the user on final time consuming step.
+  cli::cli_progress_message("Wrapping up")
+
   # Combine pages and sort on acoustic_tag_id
-  cli::cli_progress_update(status = "Wrapping up",
-                           id = pb_fetch_pages)
   detections <-
     dplyr::bind_rows(combined_results) %>%
     dplyr::arrange(stringr::str_rank(.data$acoustic_tag_id, numeric = TRUE))

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -224,14 +224,19 @@ get_acoustic_detections <- function(connection,
 
     if (nrow(fetched_page) < page_size || limit) {
       # Page isn't full = end of results.
-      cli::cli_progress_done()
       break
     }
   }
 
   # Combine pages and sort on acoustic_tag_id
-  dplyr::bind_rows(combined_results) %>%
+  cli::cli_progress_update(status = "Wrapping up",
+                           id = pb_fetch_pages)
+  detections <-
+    dplyr::bind_rows(combined_results) %>%
     dplyr::arrange(stringr::str_rank(.data$acoustic_tag_id, numeric = TRUE))
+
+  # Return single detections table
+  detections
 }
 
 #' Count acoustic detections

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -112,7 +112,7 @@ get_acoustic_detections <- function(connection,
     ]
 
   # Initialize progress bar
-  cli::cli_progress_bar()
+  cli::cli_progress_bar(auto_terminate = FALSE)
 
   # Calculate the number of records we expect: for progress bar + page_size
   n_records_expected <-

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -96,7 +96,7 @@ get_acoustic_detections <- function(connection,
     progress <- FALSE
   }
   # Only show the progress bar if less than 50% of records have been fetched in
-  # 24h
+  # 24h: workaround to control progress reporting
   if (!progress) {
     withr::local_options(cli.progress_show_after = 60 * 60 * 24)
   }
@@ -111,8 +111,10 @@ get_acoustic_detections <- function(connection,
       )
     ]
 
-  # Initialize progress bar
-  pb_fetch_pages <- cli::cli_progress_bar(status = "Preparing")
+  # Initialize progress bar for record counting
+  pb_count <- cli::cli_progress_bar("Preparing",
+                                    "tasks",
+                                    total = 1)
 
   # Calculate the number of records we expect: for progress bar + page_size
   n_records_expected <-
@@ -164,6 +166,12 @@ get_acoustic_detections <- function(connection,
     n_records_expected > 5e6 ~ 1e6,
     .default = 100000
   )
+
+  # Finish up progress bar for count step
+  cli::cli_process_done(id = pb_count)
+
+  # Initialize progress bar for fetching the pages
+  pb_fetch_pages <- cli::cli_progress_bar()
 
   # Update progress bar with total number of pages expected: plus one for the
   # count query, this update doesn't count as a progress step. Otherwise we'd

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -111,6 +111,9 @@ get_acoustic_detections <- function(connection,
       )
     ]
 
+  # Initialize progress bar
+  cli::cli_progress_bar()
+
   # Calculate the number of records we expect: for progress bar + page_size
   n_records_expected <-
     if (limit) {
@@ -162,8 +165,10 @@ get_acoustic_detections <- function(connection,
     .default = 100000
   )
 
-  # Initialize progress bar with total number of pages expected
-  cli::cli_progress_bar(total = ceiling(n_records_expected / page_size))
+  # Update progress bar with total number of pages expected: plus one for the
+  # count query
+  n_pages_expected <- ceiling(n_records_expected / page_size)
+  cli::cli_progress_update(total = n_pages_expected + 1)
 
   # Init object to store pages
   combined_results <- list()
@@ -203,8 +208,8 @@ get_acoustic_detections <- function(connection,
     # Fetch page
     fetched_page <- do.call(helper_to_use, arguments_for_helper)
 
-    # Iterate the progress bar
-    cli::cli_progress_update(inc = nrow(fetched_page))
+    # Iterate the progress bar by one page
+    cli::cli_progress_update(inc = 1)
 
     # The next page will be fetched with detection_ids higher than the current
     # max detection_id
@@ -218,6 +223,7 @@ get_acoustic_detections <- function(connection,
 
     if (nrow(fetched_page) < page_size || limit) {
       # Page isn't full = end of results.
+      cli::cli_progress_done()
       break
     }
   }

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -166,9 +166,10 @@ get_acoustic_detections <- function(connection,
   )
 
   # Update progress bar with total number of pages expected: plus one for the
-  # count query
+  # count query, this update doesn't count as a progress step. Otherwise we'd
+  # have to add 1 more to the total number of steps.
   n_pages_expected <- ceiling(n_records_expected / page_size)
-  cli::cli_progress_update(total = n_pages_expected + 1)
+  cli::cli_progress_update(total = n_pages_expected + 1, inc = 0)
 
   # Init object to store pages
   combined_results <- list()

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -241,7 +241,7 @@ get_acoustic_detections <- function(connection,
 
   # Combine pages and sort on acoustic_tag_id
   detections <-
-    dplyr::bind_rows(combined_results) %>%
+    dplyr::bind_rows(combined_results) |>
     dplyr::arrange(stringr::str_rank(.data$acoustic_tag_id, numeric = TRUE))
 
   # Return single detections table

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -114,7 +114,7 @@ get_acoustic_detections <- function(connection,
   # Calculate the number of records we expect: for progress bar + page_size
   # Report on this step as it can take a while for large queries
   if (progress) {
-    cli::cli_progress_step("Preparing")
+    cli::cli_progress_message("Preparing")
   }
   n_records_expected <-
     if (limit) {
@@ -236,8 +236,7 @@ get_acoustic_detections <- function(connection,
 
   # Update the user on final time consuming step.
   if (progress) {
-    cli::cli_alert_success("Getting data.")
-    cli::cli_progress_step("Wrapping up")
+    cli::cli_progress_message("Wrapping up")
   }
 
   # Combine pages and sort on acoustic_tag_id

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -113,7 +113,9 @@ get_acoustic_detections <- function(connection,
 
   # Calculate the number of records we expect: for progress bar + page_size
   # Report on this step as it can take a while for large queries
-  cli::cli_progress_message("Preparing...")
+  if (progress) {
+    cli::cli_progress_step("Preparing")
+  }
   n_records_expected <-
     if (limit) {
       # If limit is set to TRUE, we expect 100 records
@@ -233,7 +235,10 @@ get_acoustic_detections <- function(connection,
   }
 
   # Update the user on final time consuming step.
-  cli::cli_progress_message("Wrapping up...")
+  if (progress) {
+    cli::cli_alert_success("Getting data.")
+    cli::cli_progress_step("Wrapping up")
+  }
 
   # Combine pages and sort on acoustic_tag_id
   detections <-

--- a/tests/fixtures/count_detections.yml
+++ b/tests/fixtures/count_detections.yml
@@ -1,0 +1,42 @@
+http_interactions:
+- request:
+    method: POST
+    uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
+    body:
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"animal_project_code":"2013_albertkanaal","count":true}'
+  response:
+    status: 201
+    headers:
+      date: Mon, 22 Sep 2025 07:43:20 GMT
+      server: Apache/2.4.58 (Ubuntu)
+      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
+        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
+        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
+      cross-origin-opener-policy: same-origin
+      cache-control: max-age=300, public
+      x-ocpu-session: x072de4face768c
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x072de4face768c/
+      access-control-allow-origin: '*'
+      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
+      access-control-allow-headers: '*'
+      access-control-allow-credentials: 'true'
+      x-ocpu-r: R version 4.5.0 (2025-04-11)
+      x-ocpu-locale: C.UTF-8
+      x-ocpu-time: 2025-09-22 07:43:26 UTC
+      x-ocpu-version: 2.2.14
+      x-ocpu-server: rApache
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-length: '50'
+      content-type: application/json
+      access-control-allow-methods: '*'
+      set-cookie: vliz_webc=vliz_webc2; path=/
+    body:
+      string: |
+        [
+          {
+            "count": 5479707
+          }
+        ]
+  recorded_at: 2025-09-22 07:43:27
+recorded_with: VCR-vcr/2.0.0

--- a/tests/fixtures/detections_minimal.yml
+++ b/tests/fixtures/detections_minimal.yml
@@ -1,0 +1,173 @@
+http_interactions:
+- request:
+    method: POST
+    uri: https://opencpu.lifewatch.be/library/etnservice/R/validate_login/json/
+    body:
+      string: '{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"}'
+  response:
+    status: 201
+    headers:
+      date: Mon, 22 Sep 2025 12:54:17 GMT
+      server: Apache/2.4.58 (Ubuntu)
+      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
+        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
+        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
+      cross-origin-opener-policy: same-origin
+      cache-control: max-age=300, public
+      x-ocpu-session: x0a7e5c39105862
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0a7e5c39105862/
+      access-control-allow-origin: '*'
+      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
+      access-control-allow-headers: '*'
+      access-control-allow-credentials: 'true'
+      x-ocpu-r: R version 4.5.0 (2025-04-11)
+      x-ocpu-locale: C.UTF-8
+      x-ocpu-time: 2025-09-22 12:54:18 UTC
+      x-ocpu-version: 2.2.14
+      x-ocpu-server: rApache
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-length: '27'
+      content-type: application/json
+      access-control-allow-methods: '*'
+      set-cookie: vliz_webc=vliz_webc2; path=/
+    body:
+      string: |
+        [true]
+  recorded_at: 2025-09-22 12:54:18
+- request:
+    method: POST
+    uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/json/
+    body:
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2014-04-10","end_date":"2014-04-11","acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":"de-9","count":true}'
+  response:
+    status: 201
+    headers:
+      date: Mon, 22 Sep 2025 12:54:18 GMT
+      server: Apache/2.4.58 (Ubuntu)
+      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
+        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
+        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
+      cross-origin-opener-policy: same-origin
+      cache-control: max-age=300, public
+      x-ocpu-session: x05a9663f7d7f5d
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x05a9663f7d7f5d/
+      access-control-allow-origin: '*'
+      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
+      access-control-allow-headers: '*'
+      access-control-allow-credentials: 'true'
+      x-ocpu-r: R version 4.5.0 (2025-04-11)
+      x-ocpu-locale: C.UTF-8
+      x-ocpu-time: 2025-09-22 12:54:19 UTC
+      x-ocpu-version: 2.2.14
+      x-ocpu-server: rApache
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-length: '44'
+      content-type: application/json
+      access-control-allow-methods: '*'
+      set-cookie: vliz_webc=vliz_webc1; path=/
+    body:
+      string: |
+        [
+          {
+            "count": 7
+          }
+        ]
+  recorded_at: 2025-09-22 12:54:19
+- request:
+    method: POST
+    uri: https://opencpu.lifewatch.be/library/etnservice/R/get_acoustic_detections_page/
+    body:
+      string: '{"credentials":{"username":"<<<my_userid>>>","password":"<<<my_pwd>>>"},"start_date":"2014-04-10","end_date":"2014-04-11","acoustic_tag_id":null,"animal_project_code":null,"scientific_name":null,"acoustic_project_code":null,"deployment_id":null,"receiver_id":null,"station_name":"de-9","next_id_pk":0,"page_size":100000,"credentials.1":null}'
+  response:
+    status: 201
+    headers:
+      date: Mon, 22 Sep 2025 12:54:19 GMT
+      server: Apache/2.4.58 (Ubuntu)
+      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
+        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
+        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
+      cross-origin-opener-policy: same-origin
+      cache-control: max-age=300, public
+      x-ocpu-session: x0f3c2e6654cddf
+      location: http://opencpu.lifewatch.be/ocpu/tmp/x0f3c2e6654cddf/
+      access-control-allow-origin: '*'
+      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
+      access-control-allow-headers: '*'
+      access-control-allow-credentials: 'true'
+      x-ocpu-r: R version 4.5.0 (2025-04-11)
+      x-ocpu-locale: C.UTF-8
+      x-ocpu-time: 2025-09-22 12:54:21 UTC
+      x-ocpu-version: 2.2.14
+      x-ocpu-server: rApache
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-length: '137'
+      content-type: text/plain; charset=utf-8
+      access-control-allow-methods: '*'
+      set-cookie: vliz_webc=vliz_webc1; path=/
+    body:
+      string: |
+        /ocpu/tmp/x0f3c2e6654cddf/R/.val
+        /ocpu/tmp/x0f3c2e6654cddf/R/credentials
+        /ocpu/tmp/x0f3c2e6654cddf/R/get_acoustic_detections_page
+        /ocpu/tmp/x0f3c2e6654cddf/stdout
+        /ocpu/tmp/x0f3c2e6654cddf/source
+        /ocpu/tmp/x0f3c2e6654cddf/console
+        /ocpu/tmp/x0f3c2e6654cddf/info
+        /ocpu/tmp/x0f3c2e6654cddf/files/DESCRIPTION
+  recorded_at: 2025-09-22 12:54:21
+- request:
+    method: GET
+    uri: https://opencpu.lifewatch.be/tmp/x0f3c2e6654cddf/R/.val/rds
+  response:
+    status: 200
+    headers:
+      date: Mon, 22 Sep 2025 12:54:21 GMT
+      server: Apache/2.4.58 (Ubuntu)
+      content-security-policy: upgrade-insecure-requests; script-src * 'unsafe-inline'
+        'unsafe-eval' blob:; object-src *; frame-ancestors 'self' www.vliz.be vliz.be
+        form.vliz.be www.omes-monitoring.be omes-monitoring.be;
+      cross-origin-opener-policy: same-origin
+      cache-control: max-age=86400, public
+      content-disposition: attachment;filename=.val.rds
+      access-control-allow-origin: '*'
+      access-control-expose-headers: Location, X-ocpu-session, Content-Type, Cache-Control
+      access-control-allow-headers: '*'
+      access-control-allow-credentials: 'true'
+      x-ocpu-r: R version 4.5.0 (2025-04-11)
+      x-ocpu-locale: C.UTF-8
+      x-ocpu-time: 2025-09-22 12:54:22 UTC
+      x-ocpu-version: 2.2.14
+      x-ocpu-server: rApache
+      vary: Accept-Encoding
+      content-encoding: gzip
+      content-length: '601'
+      content-type: application/r-rds
+      access-control-allow-methods: '*'
+      set-cookie: vliz_webc=vliz_webc2; path=/
+    body:
+      raw_gzip: |-
+        eJzNVc1uEzEQ3s0Pq23TpqjpgUMfIVUSaCG3VJWQwoW/phQulrPrDUa7dll708IBeAUucOLC
+        E3DiVgk
+        kXgCJC4ceQAgJiQMnJIQEjLP2kkRUIhCpXWk8ns8z34y9/tmesSwrbxWK0IJYVrGz
+        eb56DqxFMCogcy
+        CO3Xr/0t74/NVuLxP7wsO39lZ/z77+at++sXwKfOeVz/qb148OoKP09xda
+        p/Zj90Fqf2ql+oMe/9hSO
+        Qs5aGyrYLmqAC/EQkBnASSnQefSxavtbU9q88TAlOOR8i5nREca
+        MN/Z3AD1Q8MOiPsTvn/QaXxKO7++
+        1qzW12p1aOqnV48F+v8zHPxr+FXWYTLlVSz6JCLxlI3R
+        FLNbVxrXqvXGmdrZ2hFAo8UUfFJtTq0PO0B
+        xt9r33j2/edCcVGfxlUbn2er+5Um1ib//RW0L
+        5+mkegp76ajz//150SeWsi5HPpYYBTQkxwKd0irA8X
+        tyuKh72janP29ucdkNkR+Yixos3Z1R
+        1a0EMY7I2BXvxnx3hQEudN6cWmUo49v4W2CcVMKKBks+kcSTl
+        DNEfcMIuQiSNDLrc1LiHhIk
+        pjhELIm62fVSxh5PhKQeUh4ZwSJmNALfnZjfAnLkcd9QuXoo8y0LjxIm
+        aQAkqkANL2XMfyCZ
+        jYlHaJ/Ev2lKQuLBLIY4yj7ZCfkdFMKITLLoBQNz1hvGS4IwwWPUx2GSZdJYwqh
+        5aOdSqDHi
+        VzLgkOOSoD0GU5UcMU4FQbGqMCPmSeyR4V3o3PZQEOKeyZOWGcHiqGnCe/0Lc/khsw==
+  recorded_at: 2025-09-22 12:54:22
+recorded_with: VCR-vcr/2.0.0

--- a/tests/testthat/test-get_acoustic_detections.R
+++ b/tests/testthat/test-get_acoustic_detections.R
@@ -603,3 +603,9 @@ test_that("get_acoustic_detections() can handle 5M+ detections: SQL", {
                                 api = FALSE)
   expect_s3_class(df, "data.frame")
 })
+
+# count_acoustic_detections -----------------------------------------------
+
+test_that("count_acoustic_detections() returns numeric values", {
+
+})

--- a/tests/testthat/test-get_acoustic_detections.R
+++ b/tests/testthat/test-get_acoustic_detections.R
@@ -607,5 +607,17 @@ test_that("get_acoustic_detections() can handle 5M+ detections: SQL", {
 # count_acoustic_detections -----------------------------------------------
 
 test_that("count_acoustic_detections() returns numeric values", {
+  vcr::local_cassette("count_detections")
+  count <- count_acoustic_detections(animal_project_code = "2013_albertkanaal",
+                                     api = TRUE)
+  expect_type(count, "double")
+  expect_length(count, 1L)
+})
 
+test_that("count_acoustic_detections() returns values within expected range", {
+  vcr::local_cassette("count_detections")
+  count <- count_acoustic_detections(animal_project_code = "2013_albertkanaal",
+                                     api = TRUE)
+  expect_gt(count, 5e6)
+  expect_lt(count, 1e8)
 })

--- a/tests/testthat/test-get_acoustic_detections.R
+++ b/tests/testthat/test-get_acoustic_detections.R
@@ -589,6 +589,7 @@ test_that("get_acoustic_detections() can return detections not (yet) associated 
 
 test_that("get_acoustic_detections() can handle 5M+ detections: API", {
   skip_on_ci() # This takes ages
+  skip_on_covr() # This takes ages, doesn't add coverage
   df <- get_acoustic_detections(animal_project_code = "2013_albertkanaal",
                                 limit = FALSE,
                                 api = TRUE)

--- a/tests/testthat/test-get_acoustic_detections.R
+++ b/tests/testthat/test-get_acoustic_detections.R
@@ -606,18 +606,20 @@ test_that("get_acoustic_detections() can handle 5M+ detections: SQL", {
 })
 
 test_that("get_acoustic_detection() reports no progress when disabled", {
-  # Reuse cassette
-  vcr::local_cassette("detections_station_name")
+  vcr::local_cassette("detections_minimal")
   # The function will never report progress when testing, overwrite this
   # behaviour to test the function argument.
   expect_no_message(
     with_mocked_bindings(
-      code = get_acoustic_detections(station_name = "de-9", progress = FALSE),
+      code = get_acoustic_detections(station_name = "de-9",
+                                     progress = TRUE,
+                                     api = TRUE,
+                                     start_date = "2014-04-10",
+                                     end_date = "2014-04-11"),
       # disable testing overwrite: it would never show when testing
       is_testing = function(...) {
         FALSE
-      },
-
+      }
     )
   )
 })

--- a/tests/testthat/test-get_acoustic_detections.R
+++ b/tests/testthat/test-get_acoustic_detections.R
@@ -604,6 +604,23 @@ test_that("get_acoustic_detections() can handle 5M+ detections: SQL", {
   expect_s3_class(df, "data.frame")
 })
 
+test_that("get_acoustic_detection() reports no progress when disabled", {
+  # Reuse cassette
+  vcr::local_cassette("detections_station_name")
+  # The function will never report progress when testing, overwrite this
+  # behaviour to test the function argument.
+  expect_no_message(
+    with_mocked_bindings(
+      code = get_acoustic_detections(station_name = "de-9", progress = FALSE),
+      # disable testing overwrite: it would never show when testing
+      is_testing = function(...) {
+        FALSE
+      },
+
+    )
+  )
+})
+
 # count_acoustic_detections -----------------------------------------------
 
 test_that("count_acoustic_detections() returns numeric values", {

--- a/tests/testthat/test-get_acoustic_detections.R
+++ b/tests/testthat/test-get_acoustic_detections.R
@@ -612,7 +612,7 @@ test_that("get_acoustic_detection() reports no progress when disabled", {
   expect_no_message(
     with_mocked_bindings(
       code = get_acoustic_detections(station_name = "de-9",
-                                     progress = TRUE,
+                                     progress = FALSE,
                                      api = TRUE,
                                      start_date = "2014-04-10",
                                      end_date = "2014-04-11"),


### PR DESCRIPTION
I found that a bug I had fixed #390, wasn't fixed at all. It took quite a bit of effort wrangling the progress bars in cli. The fix as easy enough, I forgot to change my progress incrementation from number of records to number of pages. But to get a UI that is not annoying but still informs the user on time consuming steps wasn't so easy. 

The trouble lies in that `get_acoustic_detections()` really has 3 time consuming components: 

- count the number of records we expect: needed for page size calculation and progress reporting in getting the pages
- actually fetching the detections one page at a time (we can calculate the number of pages) -> use a progress bar
- and collating the pages

The first and last step are hard to estimate in advance, and don't really have good intermediate states to report progress on. 

Anyway, took me a bit. It's not perfect. If I get feedback on how to improve the user experience I'll surely revisit this.

## AI Summary
This pull request improves the progress reporting and robustness of the `get_acoustic_detections` and `count_acoustic_detections` functions, especially for large queries. It also adds new tests to verify progress behavior and numeric handling of large counts. The changes enhance user feedback during long-running operations and ensure compatibility with large integer types returned by the database.

**Progress reporting improvements:**

* The progress bar initialization and updates in `get_acoustic_detections` have been refined to better reflect actual query steps, including a new "Preparing" message and a "Wrapping up" message for large queries. Progress bar handling is now more accurate for paging and count queries. [[1]](diffhunk://#diff-71306726cb6e9305f6f36adb136bcbf8c72ca1d592c162cd0225e0cfcc4bc0c8L99-R99) [[2]](diffhunk://#diff-71306726cb6e9305f6f36adb136bcbf8c72ca1d592c162cd0225e0cfcc4bc0c8R115-R118) [[3]](diffhunk://#diff-71306726cb6e9305f6f36adb136bcbf8c72ca1d592c162cd0225e0cfcc4bc0c8L165-R179) [[4]](diffhunk://#diff-71306726cb6e9305f6f36adb136bcbf8c72ca1d592c162cd0225e0cfcc4bc0c8L206-R219) [[5]](diffhunk://#diff-71306726cb6e9305f6f36adb136bcbf8c72ca1d592c162cd0225e0cfcc4bc0c8L216-R248)
* Added a test to verify that no progress messages are reported when progress is disabled, ensuring correct behavior of the `progress` argument.

**Handling large record counts:**

* The `count_acoustic_detections` function now coerces database integer results to numeric, preventing issues with `cli` progress bars and ensuring compatibility with large counts (e.g., `Integer64`).
* Added a fixture for API responses with large detection counts to support robust testing.
* Added tests to confirm that `count_acoustic_detections` returns a numeric value and that the count is within a plausible range for large datasets.

**Testing improvements:**

* Skipped slow tests on coverage runs to avoid unnecessary delays and improve test suite efficiency.