### PR TITLE
Change etnservice install prompt behaviour to install exact match not most recent version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 * `get_acoustic_detections()` now uses a different interface to the database resulting in much more detections being able to be fetched reliably. However, due to changes in the database, it'll initially result in less detections being returned for the same filter variables (but with less mistakes). (#384, #382, #323)
 * You can now select detections via `get_acoustic_detections()` using a `deployment_id` (#382, #340)
 * `get_acoustic_detections()` now returns a progress bar on large queries. (#384)
-* When using a local database connection, `etn` will now check if the installed helper package `etnservice` that is used to place these queries is up to date (same or more recent) with the one deployed via the API. This is to ensure that queries placed via the API and via the local database connection always result in consistent results. If the installed version of `etnservice` is older, you will be prompted to install a newer version. (#385)
+* When using a local database connection, `etn` will now check if the installed helper package `etnservice` that is used to place these queries is up to date with the one deployed via the API. This is to ensure that queries placed via the API and via the local database connection always result in consistent results. If the installed version of `etnservice` is older, you will be prompted to install a newer version. (#385)
 
 # etn 2.2.2
 

--- a/R/conduct_parent_to_helpers.R
+++ b/R/conduct_parent_to_helpers.R
@@ -73,6 +73,9 @@ conduct_parent_to_helpers <- function(api,
       rlang::check_installed(
         "etnservice",
         version = deployed_version,
+        # Ensure the exact version is installed, and not an even more recent
+        # version (In case OpenCPU is lagging on the Github released version).
+        compare = "==",
         reason =
           paste(
             "\nThere is a newer version of etnservice available",


### PR DESCRIPTION
Before this PR when the installed version of `etnservice` was lagging behind the one deployed on OpenCPU: the most recent available version was installed. Even if it is more recent than the one deployed.

I think it's preferable to have as exact a match as possible, this PR changes the call to `rlang::check_installed()` to try and fetch an exact match. 

This does mean that I really need to make a release for every version that is deployed to OpenCPU. But I don't expect issues there since the install command the container uses to install `etnservice` needs a release (at least, that's how I understand it). 

## AI Summary
This pull request makes a small but important change to how the `etnservice` package version is checked when using a local database connection. The update ensures that the installed version matches exactly with the version deployed via the API, rather than allowing newer versions. This helps maintain consistency between local and API queries.

* Version checking for the `etnservice` helper package now requires the installed version to be exactly equal to the API-deployed version, preventing issues if OpenCPU lags behind the latest GitHub release. (`R/conduct_parent_to_helpers.R`, [R/conduct_parent_to_helpers.RR76-R78](diffhunk://#diff-c3260b1fd6ffc3d7f9a8c3cadb3e7e48cc510f65d92a42f83bfc1ea396941210R76-R78))
* Updated documentation in `NEWS.md` to reflect the stricter version check for `etnservice`.