### PR TITLE
Switch to windows runner for minmum supported R version

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,7 +25,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
           # And minimum supported version in DESCRIPTION
-          - {os: ubuntu-latest,   r: '4.1.0'}
+          - {os: windows-latest,   r: '4.1.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #435

I'm having trouble installing odbc drivers on Ubuntu and MacOS for R4.1.0, windows should come with them bundled.