### PR TITLE
Fix typo in `get_credentials()` test

### DIFF
--- a/tests/testthat/test-get_credentials.R
+++ b/tests/testthat/test-get_credentials.R
@@ -1,7 +1,7 @@
 test_that("get_credentials() returns list with values from sys.env", {
   expect_type(
     withr::with_envvar(
-      list(ENT_USER = "testid",
+      list(ETN_USER = "testid",
            ETN_PWD = "testpwd"),
       get_credentials()
     ),


### PR DESCRIPTION
Fixes #445 