### PR TITLE
switch to local downloading feather files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,8 @@ Imports:
     readr,
     rlang,
     stringr,
-    utils
+    utils,
+    withr
 Suggests:
     formattable,
     frictionless,
@@ -51,8 +52,7 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0),
     tidyr,
-    vcr,
-    withr
+    vcr
 VignetteBuilder: 
     knitr
 Remotes: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ BugReports: https://github.com/inbo/etn/issues
 Depends:
     R (>= 4.1)
 Imports:
-    arrow (>= 12.0.0),
+    arrow,
     askpass,
     assertthat,
     cachem,

--- a/R/utils-api.R
+++ b/R/utils-api.R
@@ -81,7 +81,9 @@ get_val <- function(temp_key,
         rds_response
       },
       "feather" = \(request) {
-        arrow::read_feather(request$url,
+        temp_featherfile <- withr::local_tempfile(fileext = ".feather")
+        req_perform_opencpu(request, path = temp_featherfile)
+        arrow::read_feather(temp_featherfile,
                             mmap = FALSE)
       }
     )


### PR DESCRIPTION
Switch to writing to tempfile then reading: arrow needs random access older versions of arrow do not have this built in.

Setting the min arrow version to 12 would also fix this, but the windows runner for R 4.1.0 can't install arrow 23.0.0 (latest as of writing). 