### PR TITLE
Add @examples and @return when missing.

### DIFF
--- a/R/connect_to_etn.R
+++ b/R/connect_to_etn.R
@@ -11,7 +11,7 @@
 #'
 #' @export
 #' @examples
-#' dontrun{
+#' \dontrun{
 #' # This will result in a deprecation warning!
 #' my_connection <- connect_to_etn()
 #' }

--- a/R/connect_to_etn.R
+++ b/R/connect_to_etn.R
@@ -7,9 +7,14 @@
 #'
 #' @param ... Any arguments passed to this function are ignored.
 #'
-#' @return This function is no longer in use, and returns NULL invisibly.
+#' @return This function is no longer in use, and returns `NULL` invisibly.
 #'
 #' @export
+#' @examples
+#' dontrun{
+#' # This will result in a deprecation warning!
+#' my_connection <- connect_to_etn()
+#' }
 connect_to_etn <- function(...) {
   lifecycle::deprecate_warn(
     when = "3.0.0",

--- a/R/download_acoustic_dataset.R
+++ b/R/download_acoustic_dataset.R
@@ -43,6 +43,8 @@
 #'   Defaults to creating a directory named after animal project code. Existing
 #'   files of the same name will be overwritten.
 #'
+#' @return `NULL`
+#'
 #' @inheritParams list_animal_ids
 #' @export
 #'

--- a/R/download_acoustic_dataset.R
+++ b/R/download_acoustic_dataset.R
@@ -43,7 +43,7 @@
 #'   Defaults to creating a directory named after animal project code. Existing
 #'   files of the same name will be overwritten.
 #'
-#' @return `NULL`
+#' @return CSV and JSON files written to disk.
 #'
 #' @inheritParams list_animal_ids
 #' @export

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -43,6 +43,11 @@
 #'   Duplicate detections (same animal, tag and timestamp) are excluded.
 #'   It is possible for a deployment to contain no detections, e.g. if the
 #'   tag malfunctioned right after deployment.
+#'
+#' @examples
+#' # Write Darwin Core files for a specific animal project to the current directory
+#' write_dwc(animal_project_code = "cpod-lifewatch")
+#'
 write_dwc <- function(connection,
                       animal_project_code,
                       directory = ".",

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -45,9 +45,12 @@
 #'   tag malfunctioned right after deployment.
 #'
 #' @examples
-#' # Write Darwin Core files for a specific animal project to the current directory
-#' write_dwc(animal_project_code = "cpod-lifewatch")
-#'
+#' \dontrun{
+#' # Return a list of data.frames in Darwin Core format.
+#' write_dwc(animal_project_code = "2010_phd_reubens", directory = NULL)
+#' # Download files to disk
+#' write_dwc("2014_demer", directory = ".")
+#' }
 write_dwc <- function(connection,
                       animal_project_code,
                       directory = ".",

--- a/man/connect_to_etn.Rd
+++ b/man/connect_to_etn.Rd
@@ -10,11 +10,17 @@ connect_to_etn(...)
 \item{...}{Any arguments passed to this function are ignored.}
 }
 \value{
-This function is no longer in use, and returns NULL invisibly.
+This function is no longer in use, and returns \code{NULL} invisibly.
 }
 \description{
 This function is \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} since etn version 3.0.0.
 Its use is no longer supported or needed. All connections to the ETN database
 are now handled automatically when you use a function. If your credentials
 are not stored in the system environment, you will be prompted to enter them.
+}
+\examples{
+dontrun{
+# This will result in a deprecation warning!
+my_connection <- connect_to_etn()
+}
 }

--- a/man/connect_to_etn.Rd
+++ b/man/connect_to_etn.Rd
@@ -19,7 +19,7 @@ are now handled automatically when you use a function. If your credentials
 are not stored in the system environment, you will be prompted to enter them.
 }
 \examples{
-dontrun{
+\dontrun{
 # This will result in a deprecation warning!
 my_connection <- connect_to_etn()
 }

--- a/man/download_acoustic_dataset.Rd
+++ b/man/download_acoustic_dataset.Rd
@@ -27,7 +27,7 @@ Defaults to creating a directory named after animal project code. Existing
 files of the same name will be overwritten.}
 }
 \value{
-\code{NULL}
+CSV and JSON files written to disk.
 }
 \description{
 Download all acoustic data related to an \strong{animal project} as a data

--- a/man/download_acoustic_dataset.Rd
+++ b/man/download_acoustic_dataset.Rd
@@ -26,6 +26,9 @@ Defaults to no all (all scientific names, include "Sync tag", etc.).}
 Defaults to creating a directory named after animal project code. Existing
 files of the same name will be overwritten.}
 }
+\value{
+\code{NULL}
+}
 \description{
 Download all acoustic data related to an \strong{animal project} as a data
 package that can be deposited in a research data repository. Includes option

--- a/man/write_dwc.Rd
+++ b/man/write_dwc.Rd
@@ -71,3 +71,11 @@ tag malfunctioned right after deployment.
 }
 }
 
+\examples{
+\dontrun{
+# Return a list of data.frames in Darwin Core format.
+write_dwc(animal_project_code = "2010_phd_reubens", directory = NULL)
+# Download files to disk
+write_dwc("2014_demer", directory = ".")
+}
+}


### PR DESCRIPTION
I added a @return to download_acoustic_datasets() (NULL, side effect) and examples that don't actually run to connect_to_etn() (a warning) and write_dwc() (side effects). 