### PR TITLE
Selectivly implement extrachecks advice

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^README\.Rmd$
 ^CITATION\.cff$
 ^\.github$
+^LICENSE\.md$

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,2 @@
-MIT License
-
-Copyright (c) 2017 Instituut voor Natuur en Bosonderzoek (INBO)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+YEAR: 2026
+COPYRIGHT HOLDER: Research Institute for Nature and Forest (INBO)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2026 Research Institute for Nature and Forest (INBO)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/R/download_acoustic_dataset.R
+++ b/R/download_acoustic_dataset.R
@@ -48,10 +48,10 @@
 #' @inheritParams list_animal_ids
 #' @export
 #'
-#' @examples
-#' \dontrun{
+#' @examplesIf interactive()
 #' # Download data for the 2012_leopoldkanaal animal project (all scientific names)
-#' download_acoustic_dataset(animal_project_code = "2012_leopoldkanaal")
+#' download_acoustic_dataset(animal_project_code = "2012_leopoldkanaal",
+#'                          directory = tempdir())
 #' #> Downloading data to directory `2012_leopoldkanaal`:
 #' #> * (1/6): downloading animals.csv
 #' #> * (2/6): downloading tags.csv
@@ -74,7 +74,6 @@
 #' #> Warning message:
 #' #> In download_acoustic_dataset(animal_project_code = "2012_leopoldkanaal") :
 #' #> Found tags associated with multiple animals: 1145373
-#' }
 download_acoustic_dataset <- function(connection,
                                       animal_project_code,
                                       scientific_name = NULL,

--- a/R/utils-api.R
+++ b/R/utils-api.R
@@ -48,7 +48,7 @@ extract_temp_key <- function(response) {
 #' @noRd
 #' @examples
 #' \dontrun{
-#' etn:::extract_temp_key(response) |> get_val()
+#' extract_temp_key(response) |> get_val()
 #' }
 #'
 #' # using the opencpu test instance
@@ -56,8 +56,8 @@ extract_temp_key <- function(response) {
 #' httr2::request(api_url) |>
 #'  httr2::req_body_json(list(n = 10, mean = 5)) |>
 #'  httr2::req_perform() |>
-#'  etn:::extract_temp_key() |>
-#'  etn:::get_val(api_domain = "https://cloud.opencpu.org/ocpu")
+#'  extract_temp_key() |>
+#'  get_val(api_domain = "https://cloud.opencpu.org/ocpu")
 get_val <- function(temp_key,
                     api_domain = "https://opencpu.lifewatch.be",
                     format = c("feather", "rds"),
@@ -191,7 +191,7 @@ validate_login <- function(domain = Sys.getenv("ETN_TEST_API",
 #' @family helper functions
 #' @noRd
 #' @examples
-#' etn:::get_hostname("https://opencpu.lifewatch.be/library/etnservice/R")
+#' get_hostname("https://opencpu.lifewatch.be/library/etnservice/R")
 get_hostname <- function(url_str) {
   # the hostname + everything in the path before `library`, because opencpu
   # doesn't need to be hosted directly on the hostname. Useful for testing on

--- a/R/utils-api.R
+++ b/R/utils-api.R
@@ -56,8 +56,8 @@ extract_temp_key <- function(response) {
 #' httr2::request(api_url) |>
 #'  httr2::req_body_json(list(n = 10, mean = 5)) |>
 #'  httr2::req_perform() |>
-#'  extract_temp_key() |>
-#'  get_val(api_domain = "https://cloud.opencpu.org/ocpu")
+#'  etn:::extract_temp_key() |>
+#'  etn:::get_val(api_domain = "https://cloud.opencpu.org/ocpu")
 get_val <- function(temp_key,
                     api_domain = "https://opencpu.lifewatch.be",
                     format = c("feather", "rds"),
@@ -191,7 +191,7 @@ validate_login <- function(domain = Sys.getenv("ETN_TEST_API",
 #' @family helper functions
 #' @noRd
 #' @examples
-#' get_hostname("https://opencpu.lifewatch.be/library/etnservice/R")
+#' etn:::get_hostname("https://opencpu.lifewatch.be/library/etnservice/R")
 get_hostname <- function(url_str) {
   # the hostname + everything in the path before `library`, because opencpu
   # doesn't need to be hosted directly on the hostname. Useful for testing on

--- a/R/utils.R
+++ b/R/utils.R
@@ -106,7 +106,7 @@ deprecate_warn_connection <- function() {
 #'
 #' @examples
 #' child_fn <- function() {
-#'   get_parent_fn_name()
+#'   etn:::get_parent_fn_name()
 #' }
 #'
 #' parent_fn <- function() {
@@ -140,7 +140,7 @@ is_testing <- function() {
 #' @family helper functions
 #' @noRd
 #' @examples
-#' get_nodename()
+#' etn:::get_nodename()
 get_nodename <- function() {
   Sys.info()["nodename"]
 }
@@ -161,7 +161,7 @@ get_nodename <- function() {
 #' @examples
 #' # This should return FALSE unless you are running this example from the VLIZ
 #' # RStudio server.
-#' localdb_is_available()
+#' etn:::localdb_is_available()
 localdb_is_available <- function() {
   # As discussed with VLIZ, all systems that have access to the local database
   # should have nodenames ending on vliz.be

--- a/R/utils.R
+++ b/R/utils.R
@@ -106,7 +106,7 @@ deprecate_warn_connection <- function() {
 #'
 #' @examples
 #' child_fn <- function() {
-#'   etn:::get_parent_fn_name()
+#'   get_parent_fn_name()
 #' }
 #'
 #' parent_fn <- function() {
@@ -140,7 +140,7 @@ is_testing <- function() {
 #' @family helper functions
 #' @noRd
 #' @examples
-#' etn:::get_nodename()
+#' get_nodename()
 get_nodename <- function() {
   Sys.info()["nodename"]
 }
@@ -161,7 +161,7 @@ get_nodename <- function() {
 #' @examples
 #' # This should return FALSE unless you are running this example from the VLIZ
 #' # RStudio server.
-#' etn:::localdb_is_available()
+#' localdb_is_available()
 localdb_is_available <- function() {
   # As discussed with VLIZ, all systems that have access to the local database
   # should have nodenames ending on vliz.be

--- a/man/download_acoustic_dataset.Rd
+++ b/man/download_acoustic_dataset.Rd
@@ -68,9 +68,10 @@ performed by validation tools of the Frictionless Framework, e.g.
 \href{https://github.com/frictionlessdata/frictionless-py}{frictionless-py}.
 }
 \examples{
-\dontrun{
+\dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 # Download data for the 2012_leopoldkanaal animal project (all scientific names)
-download_acoustic_dataset(animal_project_code = "2012_leopoldkanaal")
+download_acoustic_dataset(animal_project_code = "2012_leopoldkanaal",
+                         directory = tempdir())
 #> Downloading data to directory `2012_leopoldkanaal`:
 #> * (1/6): downloading animals.csv
 #> * (2/6): downloading tags.csv
@@ -93,5 +94,5 @@ download_acoustic_dataset(animal_project_code = "2012_leopoldkanaal")
 #> Warning message:
 #> In download_acoustic_dataset(animal_project_code = "2012_leopoldkanaal") :
 #> Found tags associated with multiple animals: 1145373
-}
+\dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
Selectively implements some of the advice from https://github.com/DavisVaughan/extrachecks: ]Add namespace declaration to unexported examples, update MIT License, switch over one `\dontrun{}` to `@examplesif interactive()`

The package isn't ready for CRAN yet, but that is not the goal of the 3.0.0 release. 