### PR TITLE
Rename VLIZ to ETN RStudio server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,9 @@
 
 ## Use etn on your computer 🎉
 
-* etn now connects to the ETN database with an API provided by the [etnservice](https://github.com/inbo/etnservice) package (#280). This means you can use the package from your own computer. Note that this will be slower than running it from the [VLIZ RStudio server](https://rstudio4.vliz.be/).
-* etn will automatically switch to a local database connection when available (e.g. the VLIZ RStudio server). Use `Sys.setenv(ETN_PROTOCOL = "opencpu")` to override this behaviour and force the package to use the API (#398).
-* Queries via the API and the VLIZ RStudio Server will return the same results (#317).
+* etn now connects to the ETN database with an API provided by the [etnservice](https://github.com/inbo/etnservice) package (#280). This means you can use the package from your own computer. Note that this will be slower than running it from the [ETN RStudio server](https://rstudio.europeantrackingnetwork.org).
+* etn will automatically switch to a local database connection when available (e.g. the ETN RStudio server). Use `Sys.setenv(ETN_PROTOCOL = "opencpu")` to override this behaviour and force the package to use the API (#398).
+* Queries via the API and the ETN RStudio Server will return the same results (#317).
 * When using a local database connection, etn will check if the installed helper package etnservice that is used to place these queries is up to date with the one deployed via the API. This is to ensure that queries placed via the API and via the local database connection always result in consistent results. If the installed version of etnservice is older, you will be prompted to install a newer version (#385).
 
 ## Credentials
@@ -26,7 +26,7 @@ Your credentials (username and password) to connect to the ETN database are no l
 
 Here is how you can migrate:
 
-1. Use the new RStudio server (<https://rstudio4.vliz.be/>). The LifeWatch RStudio server (<https://rstudio.lifewatch.be>) won't work with this version of etn and will be discontinued.
+1. Use the new ETN RStudio server (<https://rstudio.europeantrackingnetwork.org>). The LifeWatch RStudio server (<https://rstudio.lifewatch.be>) won't work with this version of etn and will be discontinued.
 2. Follow the steps in `vignette("authentication")` to look up and store your credentials.
 3. Update your scripts:
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -165,7 +165,8 @@ get_nodename <- function() {
 localdb_is_available <- function() {
   # As discussed with VLIZ, all systems that have access to the local database
   # should have nodenames ending on vliz.be
-  endsWith(get_nodename(), "vliz.be")
+  endsWith(get_nodename(), "vliz.be") |
+    endsWith(get_nodename(), "europeantrackingnetwork.org")
 }
 
 #' Select the protocol to use

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -21,6 +21,12 @@ test_that("localdb_is_available() returns TRUE when nodename ends on vliz.be", {
     # Mock running on the RStudio server
     get_nodename = function(...) "rstudio4.web.vliz.be"
   )
+
+  with_mocked_bindings(
+    expect_true(localdb_is_available()),
+    # Mock running from new RStudio server
+    get_nodename = function(...) "rstudio.europeantrackingnetwork.org"
+  )
 })
 
 
@@ -31,6 +37,12 @@ test_that("select_protocol() returns 'localdb' when nodename ends on vliz.be", {
     expect_equal(select_protocol(), "localdb"),
     # Mock running on the RStudio server
     get_nodename = function(...) "rstudio4.web.vliz.be"
+  )
+
+  with_mocked_bindings(
+    expect_equal(select_protocol(), "localdb"),
+    # Mock running from new RStudio server
+    get_nodename = function(...) "rstudio.europeantrackingnetwork.org"
   )
 })
 

--- a/vignettes/authentication.Rmd
+++ b/vignettes/authentication.Rmd
@@ -59,7 +59,7 @@ Forgot the credentials to connect to the ETN database? See the section above "Wh
 
 ## Don't have an account to ETN?
 
-1. [Register for a MarinePass account](https://rshiny.lifewatch.be/account?p=register). It grants you access to several services at VLIZ: [MDA](https://mda.vliz.be/), [ETN](https://www.lifewatch.be/etn/), and the [VLIZ RStudio server](https://rstudio4.vliz.be).
+1. [Register for a MarinePass account](https://rshiny.lifewatch.be/account?p=register). It grants you access to several services at VLIZ: [MDA](https://mda.vliz.be/), [ETN](https://www.lifewatch.be/etn/), and the [ETN RStudio server](https://rstudio.europeantrackingnetwork.org).
 2. Select access to `ETN_data` and `rstudio_vliz`.
 3. Confirm registration via email.
 4. Wait for an email indicating that your account was approved by a human.


### PR DESCRIPTION
And use new URL https://rstudio.europeantrackingnetwork.org. It's an alias to the same server, but good to advertise the correct name and URL.

I've also updated the release notes on:

- GitHub: https://github.com/inbo/etn/releases/tag/v3.0.0
- Zenodo: https://zenodo.org/records/18757976
- the blog post: https://oscibio.inbo.be/blog/etn-3-0-0/