### PR TITLE
Remove references to removed vignette.

### DIFF
--- a/R/get_acoustic_deployments.R
+++ b/R/get_acoustic_deployments.R
@@ -14,8 +14,7 @@
 #'
 #' @inheritParams list_animal_ids
 #' @return A tibble with acoustic deployment data, sorted by
-#'   `acoustic_project_code`, `station_name` and `deploy_date_time`. See also
-#'  [field definitions](https://inbo.github.io/etn/articles/etn_fields.html).
+#'   `acoustic_project_code`, `station_name` and `deploy_date_time`.
 #'
 #' @export
 #'

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -25,8 +25,7 @@
 #' @inheritParams list_animal_ids
 #'
 #' @return A tibble with acoustic detections data, sorted by `acoustic_tag_id`
-#'  and `date_time`. See also
-#'  [field definitions](https://inbo.github.io/etn/articles/etn_fields.html).
+#'  and `date_time`.
 #'
 #' @export
 #'

--- a/R/get_acoustic_projects.R
+++ b/R/get_acoustic_projects.R
@@ -5,9 +5,7 @@
 #' @param acoustic_project_code Character (vector). One or more acoustic
 #'   project codes. Case-insensitive.
 #'
-#' @return A tibble with acoustic project data, sorted by `project_code`. See
-#'   also
-#'   [field definitions](https://inbo.github.io/etn/articles/etn_fields.html).
+#' @return A tibble with acoustic project data, sorted by `project_code`.
 #'
 #' @inheritParams list_animal_ids
 #' @export

--- a/R/get_acoustic_receivers.R
+++ b/R/get_acoustic_receivers.R
@@ -6,9 +6,7 @@
 #' @param status Character. One or more statuses, e.g. `available` or `broken`.
 #'
 #' @inheritParams list_animal_ids
-#' @return A tibble with acoustic receiver data, sorted by `receiver_id`. See
-#'   also
-#'   [field definitions](https://inbo.github.io/etn/articles/etn_fields.html).
+#' @return A tibble with acoustic receiver data, sorted by `receiver_id`.
 #'   Values for `owner_organization` will only be visible if you are member of
 #'   the group.
 #'

--- a/R/get_animal_projects.R
+++ b/R/get_animal_projects.R
@@ -6,9 +6,7 @@
 #'   codes. Case-insensitive.
 #'
 #' @inheritParams list_animal_ids
-#' @return A tibble with animal project data, sorted by `project_code`. See
-#'   also
-#'   [field definitions](https://inbo.github.io/etn/articles/etn_fields.html).
+#' @return A tibble with animal project data, sorted by `project_code`.
 #'
 #' @export
 #'

--- a/R/get_animals.R
+++ b/R/get_animals.R
@@ -12,8 +12,7 @@
 #' @param scientific_name Character (vector). One or more scientific names.
 #'
 #' @return A tibble with animals data, sorted by `animal_project_code`,
-#' `release_date_time` and `tag_serial_number`. See also
-#'  [field definitions](https://inbo.github.io/etn/articles/etn_fields.html).
+#' `release_date_time` and `tag_serial_number`.
 #'
 #' @inheritParams list_animal_ids
 #' @export

--- a/R/get_cpod_projects.R
+++ b/R/get_cpod_projects.R
@@ -5,9 +5,7 @@
 #' @param cpod_project_code Character (vector). One or more cpod project
 #'   codes. Case-insensitive.
 #'
-#' @return A tibble with animal project data, sorted by `project_code`. See
-#'   also
-#'   [field definitions](https://inbo.github.io/etn/articles/etn_fields.html).
+#' @return A tibble with animal project data, sorted by `project_code`.
 #'
 #' @inheritParams list_animal_ids
 #' @export

--- a/R/get_tags.R
+++ b/R/get_tags.R
@@ -12,8 +12,7 @@
 #' @param acoustic_tag_id Character (vector). One or more acoustic tag
 #'   identifiers, i.e. identifiers found in [get_acoustic_detections()].
 #'
-#' @return A tibble with tags data, sorted by `tag_serial_number`. See also
-#'  [field definitions](https://inbo.github.io/etn/articles/etn_fields.html).
+#' @return A tibble with tags data, sorted by `tag_serial_number`.
 #'  Values for `owner_organization` and `owner_pi` will only be visible if you
 #'  are member of the group.
 #'

--- a/man/get_acoustic_deployments.Rd
+++ b/man/get_acoustic_deployments.Rd
@@ -33,8 +33,7 @@ open (i.e. no end date defined). Defaults to \code{FALSE}.}
 }
 \value{
 A tibble with acoustic deployment data, sorted by
-\code{acoustic_project_code}, \code{station_name} and \code{deploy_date_time}. See also
-\href{https://inbo.github.io/etn/articles/etn_fields.html}{field definitions}.
+\code{acoustic_project_code}, \code{station_name} and \code{deploy_date_time}.
 }
 \description{
 Get data for deployments of acoustic receivers, with options to filter

--- a/man/get_acoustic_detections.Rd
+++ b/man/get_acoustic_detections.Rd
@@ -56,8 +56,7 @@ for testing purposes). Defaults to \code{FALSE}.}
 }
 \value{
 A tibble with acoustic detections data, sorted by \code{acoustic_tag_id}
-and \code{date_time}. See also
-\href{https://inbo.github.io/etn/articles/etn_fields.html}{field definitions}.
+and \code{date_time}.
 }
 \description{
 Get data for acoustic detections, with options to filter results. Use

--- a/man/get_acoustic_projects.Rd
+++ b/man/get_acoustic_projects.Rd
@@ -15,9 +15,7 @@ credentials instead.}
 project codes. Case-insensitive.}
 }
 \value{
-A tibble with acoustic project data, sorted by \code{project_code}. See
-also
-\href{https://inbo.github.io/etn/articles/etn_fields.html}{field definitions}.
+A tibble with acoustic project data, sorted by \code{project_code}.
 }
 \description{
 Get data for acoustic projects, with options to filter results.

--- a/man/get_acoustic_receivers.Rd
+++ b/man/get_acoustic_receivers.Rd
@@ -16,9 +16,7 @@ credentials instead.}
 \item{status}{Character. One or more statuses, e.g. \code{available} or \code{broken}.}
 }
 \value{
-A tibble with acoustic receiver data, sorted by \code{receiver_id}. See
-also
-\href{https://inbo.github.io/etn/articles/etn_fields.html}{field definitions}.
+A tibble with acoustic receiver data, sorted by \code{receiver_id}.
 Values for \code{owner_organization} will only be visible if you are member of
 the group.
 }

--- a/man/get_animal_projects.Rd
+++ b/man/get_animal_projects.Rd
@@ -15,9 +15,7 @@ credentials instead.}
 codes. Case-insensitive.}
 }
 \value{
-A tibble with animal project data, sorted by \code{project_code}. See
-also
-\href{https://inbo.github.io/etn/articles/etn_fields.html}{field definitions}.
+A tibble with animal project data, sorted by \code{project_code}.
 }
 \description{
 Get data for animal projects, with options to filter results.

--- a/man/get_animals.Rd
+++ b/man/get_animals.Rd
@@ -28,8 +28,7 @@ codes. Case-insensitive.}
 }
 \value{
 A tibble with animals data, sorted by \code{animal_project_code},
-\code{release_date_time} and \code{tag_serial_number}. See also
-\href{https://inbo.github.io/etn/articles/etn_fields.html}{field definitions}.
+\code{release_date_time} and \code{tag_serial_number}.
 }
 \description{
 Get data for animals, with options to filter results. Associated tag

--- a/man/get_cpod_projects.Rd
+++ b/man/get_cpod_projects.Rd
@@ -15,9 +15,7 @@ credentials instead.}
 codes. Case-insensitive.}
 }
 \value{
-A tibble with animal project data, sorted by \code{project_code}. See
-also
-\href{https://inbo.github.io/etn/articles/etn_fields.html}{field definitions}.
+A tibble with animal project data, sorted by \code{project_code}.
 }
 \description{
 Get data for cpod projects, with options to filter results.

--- a/man/get_tags.Rd
+++ b/man/get_tags.Rd
@@ -29,8 +29,7 @@ both, find those with \code{acoustic-archival}.}
 identifiers, i.e. identifiers found in \code{\link[=get_acoustic_detections]{get_acoustic_detections()}}.}
 }
 \value{
-A tibble with tags data, sorted by \code{tag_serial_number}. See also
-\href{https://inbo.github.io/etn/articles/etn_fields.html}{field definitions}.
+A tibble with tags data, sorted by \code{tag_serial_number}.
 Values for \code{owner_organization} and \code{owner_pi} will only be visible if you
 are member of the group.
 }


### PR DESCRIPTION
Some functions still referred to a vignette we removed in their roxygen2 documentation. This PR removes those lines from the documentation. 