### PR TITLE
Increase test coverage for deprecated `connection` argument

### DIFF
--- a/tests/testthat/test-utils-api.R
+++ b/tests/testthat/test-utils-api.R
@@ -169,7 +169,9 @@ test_that("deprecate_warn_connection() is triggered on all functions with connec
       error = function(e) {
         NULL
       }
-    ), class = "lifecycle_warning_deprecated")
+    ), class = "lifecycle_warning_deprecated",
+    label = sprintf("`%s()` to warn for connection deprecation",
+                    fn))
   }
 })
 

--- a/tests/testthat/test-utils-api.R
+++ b/tests/testthat/test-utils-api.R
@@ -131,6 +131,41 @@ test_that("deprecate_warn_connection() returns warning with function symbol", {
   )
 })
 
+test_that("deprecate_warn_connection() is triggered on all functions with connection arg", {
+  # List all functions with a conneciton argument
+  etn_namespace <- asNamespace("etn")
+  getNamespaceExports(etn_namespace) |>
+    purrr::keep(\(fn) {
+      "connection" %in% names(
+        formals(get(fn, envir = etn_namespace))
+      )
+    }) |>
+    # For every of these functions, run them with an invalid connection. But
+    # don't fail on any other errors. To fail early, I'm sabotaging fetching
+    # local credentials. As this happens in a downstream helper, the connection
+    # warning should fire first. This greatly speeds up the test.
+    purrr::walk(~
+      expect_warning(tryCatch(
+        expr = {
+          with_mocked_bindings(
+            code = {
+              do.call(.x,
+                args = list(connection = "not a connection object")
+              )
+            },
+            # Sabotage get_credentials() so we fail early.
+            get_credentials = function() {
+              NULL
+            }
+          )
+        },
+        # Suppress all errors downstream
+        error = function(e) {
+          NULL
+        }
+      ), class = "lifecycle_warning_deprecated"))
+})
+
 # get_parent_fn_name() ----------------------------------------------------
 
 

--- a/tests/testthat/test-utils-api.R
+++ b/tests/testthat/test-utils-api.R
@@ -150,8 +150,7 @@ test_that("deprecate_warn_connection() is triggered on all functions with connec
   # tree to select what protocol path to follow. As this happens early in a
   # downstream helper, the connection warning should fire first. This greatly
   # speeds up the test.
-  for (fn in fns_with_connection_arg)
-  {
+  for (fn in fns_with_connection_arg) {
     expect_warning(tryCatch(
       expr = {
         with_mocked_bindings(

--- a/tests/testthat/test-utils-api.R
+++ b/tests/testthat/test-utils-api.R
@@ -134,36 +134,44 @@ test_that("deprecate_warn_connection() returns warning with function symbol", {
 test_that("deprecate_warn_connection() is triggered on all functions with connection arg", {
   # List all functions with a conneciton argument
   etn_namespace <- asNamespace("etn")
-  getNamespaceExports(etn_namespace) |>
+  fns_with_connection_arg <-
+    getNamespaceExports(etn_namespace) |>
     purrr::keep(\(fn) {
       "connection" %in% names(
         formals(get(fn, envir = etn_namespace))
       )
-    }) |>
-    # For every of these functions, run them with an invalid connection. But
-    # don't fail on any other errors. To fail early, I'm sabotaging fetching
-    # local credentials. As this happens in a downstream helper, the connection
-    # warning should fire first. This greatly speeds up the test.
-    purrr::walk(~
-      expect_warning(tryCatch(
-        expr = {
-          with_mocked_bindings(
-            code = {
-              do.call(.x,
-                args = list(connection = "not a connection object")
-              )
-            },
-            # Sabotage get_credentials() so we fail early.
-            get_credentials = function() {
-              NULL
-            }
-          )
-        },
-        # Suppress all errors downstream
-        error = function(e) {
-          NULL
-        }
-      ), class = "lifecycle_warning_deprecated"))
+    })
+
+  # Check that there are still functions with a `connection` argument
+  expect_true(length(fns_with_connection_arg) > 0)
+
+  # For every of these functions, run them with an invalid connection. But
+  # don't fail on any other errors. To fail early, I'm sabotaging the decision
+  # tree to select what protocol path to follow. As this happens early in a
+  # downstream helper, the connection warning should fire first. This greatly
+  # speeds up the test.
+  for (fn in fns_with_connection_arg)
+  {
+    expect_warning(tryCatch(
+      expr = {
+        with_mocked_bindings(
+          code = {
+            do.call(fn,
+              args = list(connection = "not a connection object")
+            )
+          },
+          # Sabotage conduct_parent_to_helpers() so we fail early.
+          select_protocol = function(...) {
+            rlang::abort(class = "etn_no_protocol")
+          }
+        )
+      },
+      # Suppress all errors downstream
+      error = function(e) {
+        NULL
+      }
+    ), class = "lifecycle_warning_deprecated")
+  }
 })
 
 # get_parent_fn_name() ----------------------------------------------------


### PR DESCRIPTION
When checking coverage for a different development, I noticed that a bunch of functions have reduced coverage because the deprecation of the `connection` argument isn't actually tested on a function by function basis. This PR adds a test that does exactly this, based on the formals of the etn package namespace. 

It checks for all functions in the package, checks their arguments, keeps those with a `connection` argument, and then checks for the expected warning class when a value is passed to this argument. To avoid all these function calls taking ages to run, I cause an early failure by sabotaging the `select_protocol()` helper via local bindings, and suppress this error since I'm only interested in the deprecation warning and expect at least some functions to have required arguments.