### PR TITLE
Update function reference

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
   * [institutionCode](http://rs.tdwg.org/dwc/terms/institutionCode) is always set to `"VLIZ"` as maintainer of ETN. The `institution_code` parameter has been removed.
   * [license](http://purl.org/dc/terms/license) is set to `"CC-BY-4.0"` or `"CC0-1.0"` rather than a URL. The input for the `license` parameter has been updated accordingly.
   * [identificationVerificationStatus](http://rs.tdwg.org/dwc/terms/identificationVerificationStatus) has been added and is set to `"verified by expert"` for all records, since the taxon is assumed to be well-known before the tag was attached.
+* The [function reference](https://inbo.github.io/etn/reference/index.html) has been reorganized (#549)
 
 # etn 3.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # etn (development version)
 
 * Add European Union as funder (for [STRAITS](https://doi.org/10.3030/101094649)) (#497).
-* `get_acoustic_project()`, `get_animal_projects()` and `get_cpod_projects()` now have an optional argument `citation`, which adds the columns `citation`, `doi`, `contact_name`, `contact_email` and `contact_affiliation` to the data frame. This makes it easier to cite projects or contact the responsible. The citation information is obtained via [MarineInfo](https://marineinfo.org) (#518).
+* `get_acoustic_projects()`, `get_animal_projects()` and `get_cpod_projects()` now have an optional argument `citation`, which adds the columns `citation`, `doi`, `contact_name`, `contact_email` and `contact_affiliation` to the data frame. This makes it easier to cite projects or contact the responsible. The citation information is obtained via [MarineInfo](https://marineinfo.org) (#518).
 * New `example_dataset()` reads an example dataset (`"2014_DEMER"`) as a data package (#530).
 * `read_package()` and `write_package()` are reexported from `{frictionless}` to read and write data packages (#525).
 * `write_dwc()` now uses a data package as input, rather than reading from the ETN database (#528). This means the function can be used locally. In addition:

--- a/R/connect_to_etn.R
+++ b/R/connect_to_etn.R
@@ -6,9 +6,8 @@
 #' are not stored in the system environment, you will be prompted to enter them.
 #'
 #' @param ... Any arguments passed to this function are ignored.
-#'
 #' @return This function is no longer in use, and returns `NULL` invisibly.
-#'
+#' @family connect functions
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/download_acoustic_dataset.R
+++ b/R/download_acoustic_dataset.R
@@ -42,12 +42,10 @@
 #' @param directory Character. Relative path to local download directory.
 #'   Defaults to creating a directory named after animal project code. Existing
 #'   files of the same name will be overwritten.
-#'
-#' @return CSV and JSON files written to disk.
-#'
 #' @inheritParams list_animal_ids
+#' @return CSV and JSON files written to disk.
+#' @family download functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set() & interactive()
 #' # Download data for the 2012_leopoldkanaal animal project (all scientific names)
 #' download_acoustic_dataset(animal_project_code = "2012_leopoldkanaal",

--- a/R/frictionless-reexports.R
+++ b/R/frictionless-reexports.R
@@ -1,7 +1,9 @@
 #' @importFrom frictionless read_package
+#' @family frictionless functions
 #' @export
 frictionless::read_package
 
 #' @importFrom frictionless write_package
+#' @family frictionless functions
 #' @export
 frictionless::write_package

--- a/R/get_acoustic_deployments.R
+++ b/R/get_acoustic_deployments.R
@@ -11,13 +11,11 @@
 #'   names.
 #' @param open_only Logical. Restrict deployments to those that are currently
 #'   open (i.e. no end date defined). Defaults to `FALSE`.
-#'
 #' @inheritParams list_animal_ids
 #' @return A tibble with acoustic deployment data, sorted by
 #'   `acoustic_project_code`, `station_name` and `deploy_date_time`.
-#'
+#' @family access functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' # Get all acoustic deployments
 #' get_acoustic_deployments()

--- a/R/get_acoustic_detections.R
+++ b/R/get_acoustic_detections.R
@@ -23,12 +23,10 @@
 #' @param progress Logical. Show a progress bar while fetching data. Defaults to
 #'   `TRUE`.
 #' @inheritParams list_animal_ids
-#'
 #' @return A tibble with acoustic detections data, sorted by `acoustic_tag_id`
 #'  and `date_time`.
-#'
+#' @family access functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' # Get limited sample of acoustic detections
 #' get_acoustic_detections(limit = TRUE)

--- a/R/get_acoustic_projects.R
+++ b/R/get_acoustic_projects.R
@@ -4,13 +4,11 @@
 #'
 #' @param acoustic_project_code Character (vector). One or more acoustic
 #'   project codes. Case-insensitive.
-#'
-#' @return A tibble with acoustic project data, sorted by `project_code`.
-#'
 #' @inheritParams list_animal_ids
 #' @inheritParams get_animal_projects
+#' @return A tibble with acoustic project data, sorted by `project_code`.
+#' @family access functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' # Get all acoustic projects
 #' get_acoustic_projects()

--- a/R/get_acoustic_receivers.R
+++ b/R/get_acoustic_receivers.R
@@ -4,14 +4,12 @@
 #'
 #' @param receiver_id Character (vector). One or more receiver identifiers.
 #' @param status Character. One or more statuses, e.g. `available` or `broken`.
-#'
 #' @inheritParams list_animal_ids
 #' @return A tibble with acoustic receiver data, sorted by `receiver_id`.
 #'   Values for `owner_organization` will only be visible if you are member of
 #'   the group.
-#'
+#' @family access functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' # Get all acoustic receivers
 #' get_acoustic_receivers()

--- a/R/get_animal_projects.R
+++ b/R/get_animal_projects.R
@@ -13,12 +13,10 @@
 #'     If no contact person is provided, the first author with status `creator`.
 #'   - `contact_email`: Email address of the contact person.
 #'   - `contact_affiliation`: Institute of the contact person.
-#'
 #' @inheritParams list_animal_ids
 #' @return A tibble with animal project data, sorted by `project_code`.
-#'
+#' @family access functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' # Get all animal projects
 #' get_animal_projects()

--- a/R/get_animals.R
+++ b/R/get_animals.R
@@ -10,13 +10,11 @@
 #'   codes. Case-insensitive.
 #' @param tag_serial_number Character (vector). One or more tag serial numbers.
 #' @param scientific_name Character (vector). One or more scientific names.
-#'
+#' @inheritParams list_animal_ids
 #' @return A tibble with animals data, sorted by `animal_project_code`,
 #' `release_date_time` and `tag_serial_number`.
-#'
-#' @inheritParams list_animal_ids
+#' @family access functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' # Get all animals
 #' get_animals()

--- a/R/get_cpod_projects.R
+++ b/R/get_cpod_projects.R
@@ -4,13 +4,11 @@
 #'
 #' @param cpod_project_code Character (vector). One or more cpod project
 #'   codes. Case-insensitive.
-#'
-#' @return A tibble with animal project data, sorted by `project_code`.
-#'
 #' @inheritParams list_animal_ids
 #' @inheritParams get_animal_projects
+#' @return A tibble with animal project data, sorted by `project_code`.
+#' @family access functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' # Get all animal projects
 #' get_cpod_projects()

--- a/R/get_tags.R
+++ b/R/get_tags.R
@@ -11,14 +11,12 @@
 #'   `sentinel`.
 #' @param acoustic_tag_id Character (vector). One or more acoustic tag
 #'   identifiers, i.e. identifiers found in [get_acoustic_detections()].
-#'
+#' @inheritParams list_animal_ids
 #' @return A tibble with tags data, sorted by `tag_serial_number`.
 #'  Values for `owner_organization` and `owner_pi` will only be visible if you
 #'  are member of the group.
-#'
-#' @inheritParams list_animal_ids
+#' @family access functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' # Get all tags
 #' get_tags()

--- a/R/list_acoustic_project_codes.R
+++ b/R/list_acoustic_project_codes.R
@@ -1,12 +1,10 @@
 #' List all available acoustic project codes
 #'
-#'
+#' @inheritParams list_animal_ids
 #' @return A vector of all unique `project_code` of `type = "acoustic"` in
 #'   `project.sql`.
-#'
-#' @inheritParams list_animal_ids
+#' @family list functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' list_acoustic_project_codes()
 list_acoustic_project_codes <- function(connection) {

--- a/R/list_acoustic_tag_ids.R
+++ b/R/list_acoustic_tag_ids.R
@@ -1,11 +1,9 @@
 #' List all available acoustic tag ids
 #'
-#'
 #' @inheritParams list_animal_ids
 #' @return A vector of all unique `acoustic_tag_id` values that are available.
-#'
+#' @family list functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' list_acoustic_tag_ids()
 list_acoustic_tag_ids <- function(connection) {

--- a/R/list_animal_ids.R
+++ b/R/list_animal_ids.R
@@ -3,11 +3,9 @@
 #' @param connection `r lifecycle::badge("deprecated")` A connection to the ETN
 #'   database. This argument is no longer used. You will be prompted for
 #'   credentials instead.
-#'
 #' @return A vector of all unique `id_pk` present in `common.animal_release`.
-#'
+#' @family list functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' list_animal_ids()
 list_animal_ids <- function(connection) {

--- a/R/list_animal_project_codes.R
+++ b/R/list_animal_project_codes.R
@@ -2,9 +2,8 @@
 #'
 #' @inheritParams list_animal_ids
 #' @return A vector of all unique `project_code` of `type = "animal"` that are available.
-#'
+#' @family list functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' list_animal_project_codes()
 list_animal_project_codes <- function(connection) {

--- a/R/list_cpod_project_codes.R
+++ b/R/list_cpod_project_codes.R
@@ -2,9 +2,8 @@
 #'
 #' @inheritParams list_animal_ids
 #' @return A vector of all unique `project_code` of `type = "cpod"` that are available.
-#'
+#' @family list functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' list_cpod_project_codes()
 list_cpod_project_codes <- function(connection) {

--- a/R/list_deployment_ids.R
+++ b/R/list_deployment_ids.R
@@ -2,9 +2,8 @@
 #'
 #' @inheritParams list_animal_ids
 #' @return A vector of all unique `id_pk` present in `acoustic.deployments`.
-#'
+#' @family list functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' list_deployment_ids()
 list_deployment_ids <- function(connection) {

--- a/R/list_receiver_ids.R
+++ b/R/list_receiver_ids.R
@@ -2,9 +2,8 @@
 #'
 #' @inheritParams list_animal_ids
 #' @return A vector of all unique `receiver` present in `acoustic.receivers`.
-#'
+#' @family list functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' list_receiver_ids()
 list_receiver_ids <- function(connection) {

--- a/R/list_scientific_names.R
+++ b/R/list_scientific_names.R
@@ -3,9 +3,8 @@
 #' @inheritParams list_animal_ids
 #' @return A vector of all unique `scientific_name` present in
 #'   `common.animal_release`.
-#'
+#' @family list functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' list_scientific_names()
 list_scientific_names <- function(connection) {

--- a/R/list_station_names.R
+++ b/R/list_station_names.R
@@ -3,9 +3,8 @@
 #' @inheritParams list_animal_ids
 #' @return A vector of all unique `station_name` present in
 #'   `acoustic.deployments`.
-#'
+#' @family list functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' list_station_names()
 list_station_names <- function(connection) {

--- a/R/list_tag_serial_numbers.R
+++ b/R/list_tag_serial_numbers.R
@@ -3,9 +3,8 @@
 #' @inheritParams list_animal_ids
 #' @return A vector of all unique `tag_serial_numbers` present in
 #'   `common.tag_device`.
-#'
+#' @family list functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
 #' list_tag_serial_numbers()
 list_tag_serial_numbers <- function(connection) {

--- a/R/list_values.R
+++ b/R/list_values.R
@@ -10,13 +10,10 @@
 #' @param split Character (vector). Character or regular expression(s) passed
 #'   to [strsplit()] to split column values before returning unique values.
 #'   Defaults to `,`.
-#'
 #' @return A vector of the same type as the given column.
-#'
+#' @family list functions
 #' @export
-#'
 #' @examplesIf etn:::credentials_are_set()
-#'
 #' # List unique scientific_name from a dataframe containing animal information
 #' df <- get_animals(animal_project_code = "2014_demer")
 #' list_values(df, "scientific_name")

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -19,6 +19,7 @@
 #'   rights over the data.
 #' @return CSV and `meta.xml` files written to disk.
 #'   And invisibly, a list of data frames with the transformed data.
+#' @family transformation functions
 #' @export
 #' @section Transformation details:
 #' This function **follows recommendations** discussed and created by Peter

--- a/man/connect_to_etn.Rd
+++ b/man/connect_to_etn.Rd
@@ -24,3 +24,4 @@ are not stored in the system environment, you will be prompted to enter them.
 my_connection <- connect_to_etn()
 }
 }
+\concept{connect functions}

--- a/man/download_acoustic_dataset.Rd
+++ b/man/download_acoustic_dataset.Rd
@@ -96,3 +96,4 @@ download_acoustic_dataset(animal_project_code = "2012_leopoldkanaal",
 #> Found tags associated with multiple animals: 1145373
 \dontshow{\}) # examplesIf}
 }
+\concept{download functions}

--- a/man/get_acoustic_deployments.Rd
+++ b/man/get_acoustic_deployments.Rd
@@ -60,3 +60,14 @@ get_acoustic_deployments(acoustic_project_code = "demer")
 get_acoustic_deployments(station_name = c("de-9", "de-10"))
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other access functions: 
+\code{\link{get_acoustic_detections}()},
+\code{\link{get_acoustic_projects}()},
+\code{\link{get_acoustic_receivers}()},
+\code{\link{get_animal_projects}()},
+\code{\link{get_animals}()},
+\code{\link{get_cpod_projects}()},
+\code{\link{get_tags}()}
+}
+\concept{access functions}

--- a/man/get_acoustic_detections.Rd
+++ b/man/get_acoustic_detections.Rd
@@ -105,3 +105,14 @@ get_acoustic_detections(
 )
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other access functions: 
+\code{\link{get_acoustic_deployments}()},
+\code{\link{get_acoustic_projects}()},
+\code{\link{get_acoustic_receivers}()},
+\code{\link{get_animal_projects}()},
+\code{\link{get_animals}()},
+\code{\link{get_cpod_projects}()},
+\code{\link{get_tags}()}
+}
+\concept{access functions}

--- a/man/get_acoustic_projects.Rd
+++ b/man/get_acoustic_projects.Rd
@@ -45,3 +45,14 @@ get_acoustic_projects()
 get_acoustic_projects(acoustic_project_code = "demer", citation = TRUE)
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other access functions: 
+\code{\link{get_acoustic_deployments}()},
+\code{\link{get_acoustic_detections}()},
+\code{\link{get_acoustic_receivers}()},
+\code{\link{get_animal_projects}()},
+\code{\link{get_animals}()},
+\code{\link{get_cpod_projects}()},
+\code{\link{get_tags}()}
+}
+\concept{access functions}

--- a/man/get_acoustic_receivers.Rd
+++ b/man/get_acoustic_receivers.Rd
@@ -35,3 +35,14 @@ get_acoustic_receivers(status = c("lost", "broken"))
 get_acoustic_receivers(receiver_id = "VR2W-124070")
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other access functions: 
+\code{\link{get_acoustic_deployments}()},
+\code{\link{get_acoustic_detections}()},
+\code{\link{get_acoustic_projects}()},
+\code{\link{get_animal_projects}()},
+\code{\link{get_animals}()},
+\code{\link{get_cpod_projects}()},
+\code{\link{get_tags}()}
+}
+\concept{access functions}

--- a/man/get_animal_projects.Rd
+++ b/man/get_animal_projects.Rd
@@ -41,3 +41,14 @@ get_animal_projects()
 get_animal_projects(animal_project_code = "2014_demer", citation = TRUE)
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other access functions: 
+\code{\link{get_acoustic_deployments}()},
+\code{\link{get_acoustic_detections}()},
+\code{\link{get_acoustic_projects}()},
+\code{\link{get_acoustic_receivers}()},
+\code{\link{get_animals}()},
+\code{\link{get_cpod_projects}()},
+\code{\link{get_tags}()}
+}
+\concept{access functions}

--- a/man/get_animals.Rd
+++ b/man/get_animals.Rd
@@ -59,3 +59,14 @@ get_animals(scientific_name = c("Rutilus rutilus", "Silurus glanis"))
 get_animals(animal_project_code = "2014_demer", scientific_name = "Rutilus rutilus")
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other access functions: 
+\code{\link{get_acoustic_deployments}()},
+\code{\link{get_acoustic_detections}()},
+\code{\link{get_acoustic_projects}()},
+\code{\link{get_acoustic_receivers}()},
+\code{\link{get_animal_projects}()},
+\code{\link{get_cpod_projects}()},
+\code{\link{get_tags}()}
+}
+\concept{access functions}

--- a/man/get_cpod_projects.Rd
+++ b/man/get_cpod_projects.Rd
@@ -41,3 +41,14 @@ get_cpod_projects()
 get_cpod_projects(cpod_project_code = "cpod-lifewatch", citation = TRUE)
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other access functions: 
+\code{\link{get_acoustic_deployments}()},
+\code{\link{get_acoustic_detections}()},
+\code{\link{get_acoustic_projects}()},
+\code{\link{get_acoustic_receivers}()},
+\code{\link{get_animal_projects}()},
+\code{\link{get_animals}()},
+\code{\link{get_tags}()}
+}
+\concept{access functions}

--- a/man/get_tags.Rd
+++ b/man/get_tags.Rd
@@ -55,3 +55,14 @@ get_tags(acoustic_tag_id = "A69-1601-16130")
 get_tags(acoustic_tag_id = c("A69-1601-16129", "A69-1601-16130"))
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other access functions: 
+\code{\link{get_acoustic_deployments}()},
+\code{\link{get_acoustic_detections}()},
+\code{\link{get_acoustic_projects}()},
+\code{\link{get_acoustic_receivers}()},
+\code{\link{get_animal_projects}()},
+\code{\link{get_animals}()},
+\code{\link{get_cpod_projects}()}
+}
+\concept{access functions}

--- a/man/list_acoustic_project_codes.Rd
+++ b/man/list_acoustic_project_codes.Rd
@@ -23,3 +23,17 @@ List all available acoustic project codes
 list_acoustic_project_codes()
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other list functions: 
+\code{\link{list_acoustic_tag_ids}()},
+\code{\link{list_animal_ids}()},
+\code{\link{list_animal_project_codes}()},
+\code{\link{list_cpod_project_codes}()},
+\code{\link{list_deployment_ids}()},
+\code{\link{list_receiver_ids}()},
+\code{\link{list_scientific_names}()},
+\code{\link{list_station_names}()},
+\code{\link{list_tag_serial_numbers}()},
+\code{\link{list_values}()}
+}
+\concept{list functions}

--- a/man/list_acoustic_tag_ids.Rd
+++ b/man/list_acoustic_tag_ids.Rd
@@ -22,3 +22,17 @@ List all available acoustic tag ids
 list_acoustic_tag_ids()
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other list functions: 
+\code{\link{list_acoustic_project_codes}()},
+\code{\link{list_animal_ids}()},
+\code{\link{list_animal_project_codes}()},
+\code{\link{list_cpod_project_codes}()},
+\code{\link{list_deployment_ids}()},
+\code{\link{list_receiver_ids}()},
+\code{\link{list_scientific_names}()},
+\code{\link{list_station_names}()},
+\code{\link{list_tag_serial_numbers}()},
+\code{\link{list_values}()}
+}
+\concept{list functions}

--- a/man/list_animal_ids.Rd
+++ b/man/list_animal_ids.Rd
@@ -22,3 +22,17 @@ List all available animal ids
 list_animal_ids()
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other list functions: 
+\code{\link{list_acoustic_project_codes}()},
+\code{\link{list_acoustic_tag_ids}()},
+\code{\link{list_animal_project_codes}()},
+\code{\link{list_cpod_project_codes}()},
+\code{\link{list_deployment_ids}()},
+\code{\link{list_receiver_ids}()},
+\code{\link{list_scientific_names}()},
+\code{\link{list_station_names}()},
+\code{\link{list_tag_serial_numbers}()},
+\code{\link{list_values}()}
+}
+\concept{list functions}

--- a/man/list_animal_project_codes.Rd
+++ b/man/list_animal_project_codes.Rd
@@ -22,3 +22,17 @@ List all available animal project codes
 list_animal_project_codes()
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other list functions: 
+\code{\link{list_acoustic_project_codes}()},
+\code{\link{list_acoustic_tag_ids}()},
+\code{\link{list_animal_ids}()},
+\code{\link{list_cpod_project_codes}()},
+\code{\link{list_deployment_ids}()},
+\code{\link{list_receiver_ids}()},
+\code{\link{list_scientific_names}()},
+\code{\link{list_station_names}()},
+\code{\link{list_tag_serial_numbers}()},
+\code{\link{list_values}()}
+}
+\concept{list functions}

--- a/man/list_cpod_project_codes.Rd
+++ b/man/list_cpod_project_codes.Rd
@@ -22,3 +22,17 @@ List all available cpod project codes
 list_cpod_project_codes()
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other list functions: 
+\code{\link{list_acoustic_project_codes}()},
+\code{\link{list_acoustic_tag_ids}()},
+\code{\link{list_animal_ids}()},
+\code{\link{list_animal_project_codes}()},
+\code{\link{list_deployment_ids}()},
+\code{\link{list_receiver_ids}()},
+\code{\link{list_scientific_names}()},
+\code{\link{list_station_names}()},
+\code{\link{list_tag_serial_numbers}()},
+\code{\link{list_values}()}
+}
+\concept{list functions}

--- a/man/list_deployment_ids.Rd
+++ b/man/list_deployment_ids.Rd
@@ -22,3 +22,17 @@ List all available receiver ids
 list_deployment_ids()
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other list functions: 
+\code{\link{list_acoustic_project_codes}()},
+\code{\link{list_acoustic_tag_ids}()},
+\code{\link{list_animal_ids}()},
+\code{\link{list_animal_project_codes}()},
+\code{\link{list_cpod_project_codes}()},
+\code{\link{list_receiver_ids}()},
+\code{\link{list_scientific_names}()},
+\code{\link{list_station_names}()},
+\code{\link{list_tag_serial_numbers}()},
+\code{\link{list_values}()}
+}
+\concept{list functions}

--- a/man/list_receiver_ids.Rd
+++ b/man/list_receiver_ids.Rd
@@ -22,3 +22,17 @@ List all available receiver ids
 list_receiver_ids()
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other list functions: 
+\code{\link{list_acoustic_project_codes}()},
+\code{\link{list_acoustic_tag_ids}()},
+\code{\link{list_animal_ids}()},
+\code{\link{list_animal_project_codes}()},
+\code{\link{list_cpod_project_codes}()},
+\code{\link{list_deployment_ids}()},
+\code{\link{list_scientific_names}()},
+\code{\link{list_station_names}()},
+\code{\link{list_tag_serial_numbers}()},
+\code{\link{list_values}()}
+}
+\concept{list functions}

--- a/man/list_scientific_names.Rd
+++ b/man/list_scientific_names.Rd
@@ -23,3 +23,17 @@ List all available scientific names
 list_scientific_names()
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other list functions: 
+\code{\link{list_acoustic_project_codes}()},
+\code{\link{list_acoustic_tag_ids}()},
+\code{\link{list_animal_ids}()},
+\code{\link{list_animal_project_codes}()},
+\code{\link{list_cpod_project_codes}()},
+\code{\link{list_deployment_ids}()},
+\code{\link{list_receiver_ids}()},
+\code{\link{list_station_names}()},
+\code{\link{list_tag_serial_numbers}()},
+\code{\link{list_values}()}
+}
+\concept{list functions}

--- a/man/list_station_names.Rd
+++ b/man/list_station_names.Rd
@@ -23,3 +23,17 @@ List all available station names
 list_station_names()
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other list functions: 
+\code{\link{list_acoustic_project_codes}()},
+\code{\link{list_acoustic_tag_ids}()},
+\code{\link{list_animal_ids}()},
+\code{\link{list_animal_project_codes}()},
+\code{\link{list_cpod_project_codes}()},
+\code{\link{list_deployment_ids}()},
+\code{\link{list_receiver_ids}()},
+\code{\link{list_scientific_names}()},
+\code{\link{list_tag_serial_numbers}()},
+\code{\link{list_values}()}
+}
+\concept{list functions}

--- a/man/list_tag_serial_numbers.Rd
+++ b/man/list_tag_serial_numbers.Rd
@@ -23,3 +23,17 @@ List all available tag serial numbers
 list_tag_serial_numbers()
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other list functions: 
+\code{\link{list_acoustic_project_codes}()},
+\code{\link{list_acoustic_tag_ids}()},
+\code{\link{list_animal_ids}()},
+\code{\link{list_animal_project_codes}()},
+\code{\link{list_cpod_project_codes}()},
+\code{\link{list_deployment_ids}()},
+\code{\link{list_receiver_ids}()},
+\code{\link{list_scientific_names}()},
+\code{\link{list_station_names}()},
+\code{\link{list_values}()}
+}
+\concept{list functions}

--- a/man/list_values.Rd
+++ b/man/list_values.Rd
@@ -26,7 +26,6 @@ Concatenated values (\verb{A,B}) in the column can be returned as single values
 }
 \examples{
 \dontshow{if (etn:::credentials_are_set()) withAutoprint(\{ # examplesIf}
-
 # List unique scientific_name from a dataframe containing animal information
 df <- get_animals(animal_project_code = "2014_demer")
 list_values(df, "scientific_name")
@@ -48,3 +47,17 @@ list_values(df, tag_serial_number)
 list_values(df, tag_serial_number, split = "\\\\.")
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other list functions: 
+\code{\link{list_acoustic_project_codes}()},
+\code{\link{list_acoustic_tag_ids}()},
+\code{\link{list_animal_ids}()},
+\code{\link{list_animal_project_codes}()},
+\code{\link{list_cpod_project_codes}()},
+\code{\link{list_deployment_ids}()},
+\code{\link{list_receiver_ids}()},
+\code{\link{list_scientific_names}()},
+\code{\link{list_station_names}()},
+\code{\link{list_tag_serial_numbers}()}
+}
+\concept{list functions}

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -6,6 +6,7 @@
 \alias{read_package}
 \alias{write_package}
 \title{Objects exported from other packages}
+\concept{frictionless functions}
 \keyword{internal}
 \description{
 These objects are imported from other packages. Follow the links

--- a/man/write_dwc.Rd
+++ b/man/write_dwc.Rd
@@ -95,3 +95,4 @@ write_dwc(
 # Clean up (don't do this if you want to keep your files)
 unlink("my_directory", recursive = TRUE)
 }
+\concept{transformation functions}

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -8,32 +8,22 @@ home:
   - text: Go to the ETN data portal
     href: http://lifewatch.be/etn/
 reference:
-- title: Explore acoustic telemetry data
+- title: Access data from ETN
   contents:
-  - get_animal_projects
-  - get_animals
-  - get_tags
-  - get_acoustic_projects
-  - get_acoustic_detections
-  - get_acoustic_deployments
-  - get_acoustic_receivers
-  - download_acoustic_dataset
-  - write_dwc
-- title: Explore archival data
+  - has_concept("access functions")
+- title: Work with animal project datasets
   contents:
-  - get_animal_projects
-  - get_animals
-  - get_tags
-- title: Explore CPOD data
-  contents: get_cpod_projects
-- title: List parameter options
-  contents: starts_with("list_")
-- title: Example datasets
-  contents:
-  - example_dataset
-- title: Frictionless data package functions
-  contents:
+  # - get_package
+  - has_concept("transformation functions")
   - read_package
   - write_package
+- title: Sample datasets
+  contents:
+  - has_concept("sample data")
+- title: List parameter options
+  contents:
+  - has_concept("list functions")
 - title: Deprecated functions
-  contents: connect_to_etn
+  contents:
+  - connect_to_etn
+  - download_acoustic_dataset


### PR DESCRIPTION
Fix #526 

- Added `@family` to every public function. That means functions within a family will refer to each other:

<img width="765" height="147" alt="Screenshot 2026-04-16 at 14 08 48" src="https://github.com/user-attachments/assets/24e63cb0-30b7-4169-b57b-d964143d72aa" />


- Used consistent roxygen order (and no empty lines) for public functions
- Updated `_pkgdown.yml` with function organization suggested in #526. These mainly use `has_concept("family name")` to list functions.

The one difference with the suggestion in #526 is that I renamed:

> Read and transform datasets

To:

> Work with animal project datasets

<img width="1580" height="3670" alt="Package-index-•-etn-04-16-2026_02_05_PM" src="https://github.com/user-attachments/assets/b956832a-a4eb-4110-9152-d2d261341e7a" />
