### PR TITLE
Remove CRAN badge from README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -16,7 +16,6 @@ knitr::opts_chunk$set(
 # etn <a href="https://inbo.github.io/etn/"><img src="man/figures/logo.png" align="right" height="138" alt="etn website" /></a>
 
 <!-- badges: start -->
-[![CRAN status](https://www.r-pkg.org/badges/version/etn)](https://CRAN.R-project.org/package=etn)
 [![R-universe version](https://inbo.r-universe.dev/etn/badges/version)](https://inbo.r-universe.dev/etn)
 [![R-CMD-check](https://github.com/inbo/etn/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/inbo/etn/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/gh/inbo/etn/branch/main/graph/badge.svg)](https://app.codecov.io/gh/inbo/etn)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 
 <!-- badges: start -->
 
-[![CRAN
-status](https://www.r-pkg.org/badges/version/etn)](https://CRAN.R-project.org/package=etn)
 [![R-universe
 version](https://inbo.r-universe.dev/etn/badges/version)](https://inbo.r-universe.dev/etn)
 [![R-CMD-check](https://github.com/inbo/etn/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/inbo/etn/actions/workflows/R-CMD-check.yaml)


### PR DESCRIPTION
The badge never displays properly at the moment because the package is not published to CRAN. Let's add it back in if//when we ever publish it to them. 

