### PR TITLE
Increasing dplyr version to ">= 1.2.0"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     assertthat,
     cachem,
     cli,
-    dplyr,
+    dplyr (>= 1.2.0),
     frictionless,
     glue,
     httr2,


### PR DESCRIPTION
- fix #577 