### PR TITLE
Increase precision in minimum R version requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ License: MIT + file LICENSE
 URL: https://github.com/inbo/etn, https://inbo.github.io/etn/
 BugReports: https://github.com/inbo/etn/issues
 Depends:
-    R (>= 4.1)
+    R (>= 4.1.0)
 Imports:
     arrow,
     askpass,


### PR DESCRIPTION
I upped the minimum R version requirement from R4.1 to R4.1.0, this shouldn't make a practical difference but is more precise. 

dplyr does it the same way. 

Thanks @peterdesmet for the suggestion. 