### PR TITLE
Declare the minimum httr2 version.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Imports:
     dplyr (>= 1.2.0),
     frictionless,
     glue,
-    httr2,
+    httr2 (>= 1.2.0),
     lifecycle,
     memoise,
     methods,

--- a/codemeta.json
+++ b/codemeta.json
@@ -252,7 +252,7 @@
       "@type": "SoftwareApplication",
       "identifier": "R",
       "name": "R",
-      "version": ">= 4.1"
+      "version": ">= 4.1.0"
     },
     "2": {
       "@type": "SoftwareApplication",
@@ -318,6 +318,7 @@
       "@type": "SoftwareApplication",
       "identifier": "dplyr",
       "name": "dplyr",
+      "version": ">= 1.2.0",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -354,6 +355,7 @@
       "@type": "SoftwareApplication",
       "identifier": "httr2",
       "name": "httr2",
+      "version": ">= 1.2.0",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -470,7 +472,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "89772.495KB",
+  "fileSize": "148955.814KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",


### PR DESCRIPTION
I have declared the minimum version of httr2 in DESCRIPTION because a test run on another PR was failing because a fairly old version was installed on the test machine (0.2.2).

