### PR TITLE
Use subsampling not downsampling

### DIFF
--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -43,7 +43,7 @@
 #'   Sex, life stage and weight are (additionally) provided in an Extended
 #'   Measurement Or Facts extension, where values are mapped to a controlled
 #'   vocabulary recommended by [OBIS](https://obis.org/).
-#' - Acoustic detections are downsampled to the **first detection per hour**,
+#' - Acoustic detections are subsampled to the **first detection per hour**,
 #'   to reduce the size of high-frequency data.
 #'   The `coordinateUncertaintyInMeters` is set to 1000 m to account for
 #'   imprecise receiver location and acoustic detection range.

--- a/man/write_dwc.Rd
+++ b/man/write_dwc.Rd
@@ -67,7 +67,7 @@ life stage, comments) and deployment as a whole.
 Sex, life stage and weight are (additionally) provided in an Extended
 Measurement Or Facts extension, where values are mapped to a controlled
 vocabulary recommended by \href{https://obis.org/}{OBIS}.
-\item Acoustic detections are downsampled to the \strong{first detection per hour},
+\item Acoustic detections are subsampled to the \strong{first detection per hour},
 to reduce the size of high-frequency data.
 The \code{coordinateUncertaintyInMeters} is set to 1000 m to account for
 imprecise receiver location and acoustic detection range.


### PR DESCRIPTION
> [@PieterjanVerhelst](https://github.com/PieterjanVerhelst) suggests to use the verb `subsampling`, not `downsampling` for the Darwin Core processing. Downsampling might imply we take averages (which we don't), while `subsampling` indicates selecting a few data points (which we do).
> 
> Would be good to update everywhere in our documentation.



Note that internally subsampling was already the chosen term. 