### PR TITLE
Reduce how often CI will run during development

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types:
       - opened
+  workflow_dispatch:
 
 name: R-CMD-check.yaml
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    types:
+      - opened
 
 name: R-CMD-check.yaml
 


### PR DESCRIPTION
The CI will now run for changes to main, when a PR is opened, and then when manually triggered. 

I imagine a workflow where code changes are pushed to an open PR, but only every now and then a CI run is manually triggered. 