### PR TITLE
Switch to `frictionless::resource_names()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     cachem,
     cli,
     dplyr (>= 1.2.0),
-    frictionless,
+    frictionless (>= 1.3.0),
     glue,
     httr2 (>= 1.2.0),
     lifecycle,

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -108,7 +108,7 @@ write_dwc <- function(package, directory, dataset_id = package$id,
 
   if (!"deployments" %in% frictionless::resource_names(package)) {
     cli::cli_abort(
-      "{.arg package} must contain resource {.val deployemts}.",
+      "{.arg package} must contain resource {.val deployments}.",
       class = "etn_error_deployments_data_missing"
     )
   }

--- a/R/write_dwc.R
+++ b/R/write_dwc.R
@@ -82,7 +82,7 @@ write_dwc <- function(package, directory, dataset_id = package$id,
 
   # Read data from package
   cli::cli_h2("Reading data")
-  if (!"animals" %in% frictionless::resources(package)) {
+  if (!"animals" %in% frictionless::resource_names(package)) {
     cli::cli_abort(
       "{.arg package} must contain resource {.val animals}.",
       class = "etn_error_animals_data_missing"
@@ -90,7 +90,7 @@ write_dwc <- function(package, directory, dataset_id = package$id,
   }
   animals <- frictionless::read_resource(package, "animals")
 
-  if (!"tags" %in% frictionless::resources(package)) {
+  if (!"tags" %in% frictionless::resource_names(package)) {
     cli::cli_abort(
       "{.arg package} must contain resource {.val tags}.",
       class = "etn_error_tags_data_missing"
@@ -98,7 +98,7 @@ write_dwc <- function(package, directory, dataset_id = package$id,
   }
   tags <- frictionless::read_resource(package, "tags")
 
-  if (!"detections" %in% frictionless::resources(package)) {
+  if (!"detections" %in% frictionless::resource_names(package)) {
     cli::cli_abort(
       "{.arg package} must contain resource {.val detections}.",
       class = "etn_error_detections_data_missing"
@@ -106,7 +106,7 @@ write_dwc <- function(package, directory, dataset_id = package$id,
   }
   detections <- frictionless::read_resource(package, "detections")
 
-  if (!"deployments" %in% frictionless::resources(package)) {
+  if (!"deployments" %in% frictionless::resource_names(package)) {
     cli::cli_abort(
       "{.arg package} must contain resource {.val deployemts}.",
       class = "etn_error_deployments_data_missing"

--- a/tests/testthat/test-example_dataset.R
+++ b/tests/testthat/test-example_dataset.R
@@ -22,7 +22,7 @@ test_that("example_dataset(dataset = '2014_demer') returns a data package with
     "deployments",
     "receivers"
   )
-  expect_equal(frictionless::resources(`2014_demer`), expected_resource_names)
+  expect_equal(frictionless::resource_names(`2014_demer`), expected_resource_names)
   expect_no_error(frictionless::read_resource(`2014_demer`, "animals"))
   expect_no_error(frictionless::read_resource(`2014_demer`, "tags"))
   expect_no_error(frictionless::read_resource(`2014_demer`, "detections"))


### PR DESCRIPTION
There were warnings for usage of `frictionless::resource()` on newer versions of `frictionless`. I switched to `frictionless::resource_names()` and now require at least version 1.3.0.