### PR TITLE
Add manual approval step in R-CMD-check

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - run: echo "Approved and running R CMD CHECK"
   R-CMD-check:
+    needs: approval-gate 
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - run: echo "Approved and running R CMD CHECK"
   R-CMD-check:
-    needs: approval-gate 
+    needs: manual-gate
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    types:
-      - opened
   workflow_dispatch:
 
 name: R-CMD-check.yaml
@@ -13,6 +11,11 @@ name: R-CMD-check.yaml
 permissions: read-all
 
 jobs:
+  manual-gate:
+    runs-on: ubuntu-latest
+    environment: manual-approval   # env with "required reviewers" configured
+    steps:
+      - run: echo "Approved and running R CMD CHECK"
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -331,6 +331,7 @@
       "@type": "SoftwareApplication",
       "identifier": "frictionless",
       "name": "frictionless",
+      "version": ">= 1.3.0",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -472,7 +473,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "148955.814KB",
+  "fileSize": "148960.121KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",
@@ -517,7 +518,7 @@
       "name": "etn: Access Data from the European Tracking Network",
       "identifier": "10.5281/zenodo.15235747",
       "url": "https://inbo.github.io/etn/",
-      "description": "R package version 3.0.0",
+      "description": "R package version 3.0.0.9000",
       "@id": "https://doi.org/10.5281/zenodo.15235747",
       "sameAs": "https://doi.org/10.5281/zenodo.15235747"
     }


### PR DESCRIPTION
Currently a manual-dispatch run of R CMD Check is not being linked to the required runs for a PR. This is a workaround, the trigger is automatic, but it needs approval to actually start running. 