### PR TITLE
Require R4.2 : meet minimum requirement of `{arrow}`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,7 +32,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
           # And minimum supported version in DESCRIPTION
-          - {os: windows-latest,   r: '4.2.0'}
+          - {os: ubuntu-latest,   r: '4.2.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,7 +32,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
           # And minimum supported version in DESCRIPTION
-          - {os: windows-latest,   r: '4.1.0'}
+          - {os: windows-latest,   r: '4.2.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ License: MIT + file LICENSE
 URL: https://github.com/inbo/etn, https://inbo.github.io/etn/
 BugReports: https://github.com/inbo/etn/issues
 Depends:
-    R (>= 4.1.0)
+    R (>= 4.2.0)
 Imports:
     arrow,
     askpass,

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
   * [`dwc:identificationVerificationStatus`](http://rs.tdwg.org/dwc/terms/identificationVerificationStatus) has been added and is set to `"verified by expert"` for all records, since the taxon is assumed to be well-known before the tag was attached.
   * The animal sex, life stage and weight are added to an Extended Measurement Or Facts extension file (`emof.csv`), for better support with OBIS (#555).
 * The [function reference](https://inbo.github.io/etn/reference/index.html) has been reorganized (#549)
+* etn now relies on R >= 4.2.0 (because of the `{arrow}` dependency) (#611).
 
 # etn 3.0.0
 


### PR DESCRIPTION
Arrow formally requires R4.2. This and because it's taking a disproportionate amount of time to keep supporting R4.1.

## Todo
- [x] Mention in NEWS